### PR TITLE
Implement robust chain id checking

### DIFF
--- a/src/cometbft.rs
+++ b/src/cometbft.rs
@@ -315,6 +315,11 @@ impl Genesis {
             .expect("initial height should fit into u64")
     }
 
+    /// The identifier of the chain this genesis is for.
+    pub fn chain_id(&self) -> String {
+        self.inner.chain_id.to_string()
+    }
+
     /// The app state embedded in this genesis file.
     ///
     /// This will be an opaque value we need to then parse.

--- a/src/command/archive.rs
+++ b/src/command/archive.rs
@@ -109,7 +109,7 @@ impl ParsedCommand {
         let config = cometbft::Config::read_dir(&self.cometbft_dir)?;
         let genesis = cometbft::Genesis::read_cometbft_dir(&self.cometbft_dir, &config)?;
         let store = cometbft::Store::new(&self.cometbft_dir, &config)?;
-        let archive = Storage::new(Some(&self.archive_file)).await?;
+        let archive = Storage::new(Some(&self.archive_file), Some(&genesis.chain_id())).await?;
 
         Archiver::new(genesis, store, archive).run().await
     }

--- a/src/command/regen.rs
+++ b/src/command/regen.rs
@@ -53,7 +53,7 @@ impl Regen {
     pub async fn run(self) -> anyhow::Result<()> {
         let archive_file = self.archive_file()?;
 
-        let archive = Storage::new(Some(&archive_file)).await?;
+        let archive = Storage::new(Some(&archive_file), None).await?;
         let working_dir = self.working_dir.expect("TODO: generate temp dir");
         let indexer = Indexer::init(&self.database_url).await?;
         let regenerator = Regenerator::load(&working_dir, archive, indexer).await?;

--- a/src/penumbra/v0o79.rs
+++ b/src/penumbra/v0o79.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use async_trait::async_trait;
 use cnidarium_v0o79::Storage;
 use penumbra_app_v0o79::{app::App, PenumbraHost, SUBSTORE_PREFIXES};
-use penumbra_ibc_v0o79::component::HostInterface as _;
+use penumbra_ibc_v0o79::component::HostInterface;
 use tendermint::{
     abci::Event,
     v0_37::abci::request::{BeginBlock, DeliverTx, EndBlock},
@@ -37,8 +37,11 @@ impl super::Penumbra for Penumbra {
             .await)
     }
 
-    async fn current_height(&self) -> anyhow::Result<u64> {
-        Ok(PenumbraHost::get_block_height(self.storage.latest_snapshot()).await?)
+    async fn metadata(&self) -> anyhow::Result<(u64, String)> {
+        let snapshot = self.storage.latest_snapshot();
+        let height = PenumbraHost::get_block_height(snapshot.clone()).await?;
+        let chain_id = PenumbraHost::get_chain_id(snapshot).await?;
+        Ok((height, chain_id))
     }
 
     async fn begin_block(&mut self, req: &BeginBlock) -> Vec<Event> {

--- a/src/penumbra/v0o80.rs
+++ b/src/penumbra/v0o80.rs
@@ -37,8 +37,11 @@ impl super::Penumbra for Penumbra {
             .await)
     }
 
-    async fn current_height(&self) -> anyhow::Result<u64> {
-        Ok(PenumbraHost::get_block_height(self.storage.latest_snapshot()).await?)
+    async fn metadata(&self) -> anyhow::Result<(u64, String)> {
+        let snapshot = self.storage.latest_snapshot();
+        let height = PenumbraHost::get_block_height(snapshot.clone()).await?;
+        let chain_id = PenumbraHost::get_chain_id(snapshot).await?;
+        Ok((height, chain_id))
     }
 
     async fn begin_block(&mut self, req: &BeginBlock) -> Vec<Event> {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -174,7 +174,6 @@ impl Storage {
     }
 
     /// Get the chain id embedded in this archive format.
-    #[cfg(test)]
     pub async fn chain_id(&self) -> anyhow::Result<String> {
         let (out,) = sqlx::query_as("SELECT chain_id FROM metadata")
             .fetch_one(&self.pool)


### PR DESCRIPTION
This now stores the chain id in the archive file, and checks that:
- it matches if already present when running any archival state,
- it matches the penumbra rocksdb state when regenerating, if such a state exists.

Closes #6.