### PR TITLE
Make archival code more robust

### DIFF
--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -15,6 +15,17 @@ pub struct Indexer {
     context: Option<Context>,
 }
 
+impl Drop for Indexer {
+    fn drop(&mut self) {
+        // This assumes a multi-threaded tokio runtime.
+        tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current().block_on(async {
+                self.pool.close().await;
+            });
+        });
+    }
+}
+
 #[allow(dead_code)]
 impl Indexer {
     /// Initialize the indexer with a given database url.


### PR DESCRIPTION
This makes both database handles close on drop, to flush anything not flushed, and this removes the unnecessary concurrency in the archive command causing some of the blocks to not get put there.