### PR TITLE
chore: bump penumbra deps to v0.80.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -858,8 +858,8 @@ checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "cnidarium"
-version = "0.79.4"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.4#2c3e46c3f90afd70a5e70a77fb1044cb1bcc161f"
+version = "0.79.5"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.5#46efbca736ea95d86d40a28b2f77005047ba4c57"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -892,8 +892,8 @@ dependencies = [
 
 [[package]]
 name = "cnidarium"
-version = "0.80.2"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.80.2#56cb0025e0cece24a6301d72d46bfe7094266daf"
+version = "0.80.6"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.80.6#94b0058158d222f82781d9cbfd98d013d1c16037"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -926,24 +926,24 @@ dependencies = [
 
 [[package]]
 name = "cnidarium-component"
-version = "0.79.4"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.4#2c3e46c3f90afd70a5e70a77fb1044cb1bcc161f"
+version = "0.79.5"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.5#46efbca736ea95d86d40a28b2f77005047ba4c57"
 dependencies = [
  "anyhow",
  "async-trait",
- "cnidarium 0.79.4",
+ "cnidarium 0.79.5",
  "hex",
  "tendermint",
 ]
 
 [[package]]
 name = "cnidarium-component"
-version = "0.80.2"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.80.2#56cb0025e0cece24a6301d72d46bfe7094266daf"
+version = "0.80.6"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.80.6#94b0058158d222f82781d9cbfd98d013d1c16037"
 dependencies = [
  "anyhow",
  "async-trait",
- "cnidarium 0.80.2",
+ "cnidarium 0.80.6",
  "hex",
  "tendermint",
 ]
@@ -1159,8 +1159,8 @@ dependencies = [
 
 [[package]]
 name = "decaf377-fmd"
-version = "0.79.4"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.4#2c3e46c3f90afd70a5e70a77fb1044cb1bcc161f"
+version = "0.79.5"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.5#46efbca736ea95d86d40a28b2f77005047ba4c57"
 dependencies = [
  "ark-ff",
  "ark-serialize",
@@ -1173,8 +1173,8 @@ dependencies = [
 
 [[package]]
 name = "decaf377-fmd"
-version = "0.80.2"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.80.2#56cb0025e0cece24a6301d72d46bfe7094266daf"
+version = "0.80.6"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.80.6#94b0058158d222f82781d9cbfd98d013d1c16037"
 dependencies = [
  "ark-ff",
  "ark-serialize",
@@ -1187,8 +1187,8 @@ dependencies = [
 
 [[package]]
 name = "decaf377-ka"
-version = "0.79.4"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.4#2c3e46c3f90afd70a5e70a77fb1044cb1bcc161f"
+version = "0.79.5"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.5#46efbca736ea95d86d40a28b2f77005047ba4c57"
 dependencies = [
  "ark-ff",
  "decaf377",
@@ -1201,8 +1201,8 @@ dependencies = [
 
 [[package]]
 name = "decaf377-ka"
-version = "0.80.2"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.80.2#56cb0025e0cece24a6301d72d46bfe7094266daf"
+version = "0.80.6"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.80.6#94b0058158d222f82781d9cbfd98d013d1c16037"
 dependencies = [
  "ark-ff",
  "decaf377",
@@ -3070,8 +3070,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-app"
-version = "0.79.4"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.4#2c3e46c3f90afd70a5e70a77fb1044cb1bcc161f"
+version = "0.79.5"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.5#46efbca736ea95d86d40a28b2f77005047ba4c57"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -3081,8 +3081,8 @@ dependencies = [
  "bincode",
  "bitvec",
  "blake2b_simd 1.0.2",
- "cnidarium 0.79.4",
- "cnidarium-component 0.79.4",
+ "cnidarium 0.79.5",
+ "cnidarium-component 0.79.5",
  "decaf377",
  "decaf377-rdsa",
  "futures",
@@ -3095,29 +3095,29 @@ dependencies = [
  "metrics",
  "once_cell",
  "parking_lot",
- "penumbra-asset 0.79.4",
- "penumbra-auction 0.79.4",
- "penumbra-community-pool 0.79.4",
- "penumbra-compact-block 0.79.4",
- "penumbra-dex 0.79.4",
- "penumbra-distributions 0.79.4",
- "penumbra-fee 0.79.4",
- "penumbra-funding 0.79.4",
- "penumbra-governance 0.79.4",
- "penumbra-ibc 0.79.4",
- "penumbra-keys 0.79.4",
- "penumbra-num 0.79.4",
- "penumbra-proof-params 0.79.4",
- "penumbra-proto 0.79.4",
- "penumbra-sct 0.79.4",
- "penumbra-shielded-pool 0.79.4",
- "penumbra-stake 0.79.4",
- "penumbra-tct 0.79.4",
+ "penumbra-asset 0.79.5",
+ "penumbra-auction 0.79.5",
+ "penumbra-community-pool 0.79.5",
+ "penumbra-compact-block 0.79.5",
+ "penumbra-dex 0.79.5",
+ "penumbra-distributions 0.79.5",
+ "penumbra-fee 0.79.5",
+ "penumbra-funding 0.79.5",
+ "penumbra-governance 0.79.5",
+ "penumbra-ibc 0.79.5",
+ "penumbra-keys 0.79.5",
+ "penumbra-num 0.79.5",
+ "penumbra-proof-params 0.79.5",
+ "penumbra-proto 0.79.5",
+ "penumbra-sct 0.79.5",
+ "penumbra-shielded-pool 0.79.5",
+ "penumbra-stake 0.79.5",
+ "penumbra-tct 0.79.5",
  "penumbra-tendermint-proxy",
- "penumbra-test-subscriber 0.79.4",
- "penumbra-tower-trace 0.79.4",
- "penumbra-transaction 0.79.4",
- "penumbra-txhash 0.79.4",
+ "penumbra-test-subscriber 0.79.5",
+ "penumbra-tower-trace 0.79.5",
+ "penumbra-transaction 0.79.5",
+ "penumbra-txhash 0.79.5",
  "prost",
  "rand_chacha",
  "regex",
@@ -3145,8 +3145,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-app"
-version = "0.80.2"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.80.2#56cb0025e0cece24a6301d72d46bfe7094266daf"
+version = "0.80.6"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.80.6#94b0058158d222f82781d9cbfd98d013d1c16037"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -3156,8 +3156,8 @@ dependencies = [
  "bincode",
  "bitvec",
  "blake2b_simd 1.0.2",
- "cnidarium 0.80.2",
- "cnidarium-component 0.80.2",
+ "cnidarium 0.80.6",
+ "cnidarium-component 0.80.6",
  "decaf377",
  "decaf377-rdsa",
  "futures",
@@ -3170,28 +3170,28 @@ dependencies = [
  "metrics",
  "once_cell",
  "parking_lot",
- "penumbra-asset 0.80.2",
- "penumbra-auction 0.80.2",
- "penumbra-community-pool 0.80.2",
- "penumbra-compact-block 0.80.2",
- "penumbra-dex 0.80.2",
- "penumbra-distributions 0.80.2",
- "penumbra-fee 0.80.2",
- "penumbra-funding 0.80.2",
- "penumbra-governance 0.80.2",
- "penumbra-ibc 0.80.2",
- "penumbra-keys 0.80.2",
- "penumbra-num 0.80.2",
- "penumbra-proof-params 0.80.2",
- "penumbra-proto 0.80.2",
- "penumbra-sct 0.80.2",
- "penumbra-shielded-pool 0.80.2",
- "penumbra-stake 0.80.2",
- "penumbra-tct 0.80.2",
- "penumbra-test-subscriber 0.80.2",
- "penumbra-tower-trace 0.80.2",
- "penumbra-transaction 0.80.2",
- "penumbra-txhash 0.80.2",
+ "penumbra-asset 0.80.6",
+ "penumbra-auction 0.80.6",
+ "penumbra-community-pool 0.80.6",
+ "penumbra-compact-block 0.80.6",
+ "penumbra-dex 0.80.6",
+ "penumbra-distributions 0.80.6",
+ "penumbra-fee 0.80.6",
+ "penumbra-funding 0.80.6",
+ "penumbra-governance 0.80.6",
+ "penumbra-ibc 0.80.6",
+ "penumbra-keys 0.80.6",
+ "penumbra-num 0.80.6",
+ "penumbra-proof-params 0.80.6",
+ "penumbra-proto 0.80.6",
+ "penumbra-sct 0.80.6",
+ "penumbra-shielded-pool 0.80.6",
+ "penumbra-stake 0.80.6",
+ "penumbra-tct 0.80.6",
+ "penumbra-test-subscriber 0.80.6",
+ "penumbra-tower-trace 0.80.6",
+ "penumbra-transaction 0.80.6",
+ "penumbra-txhash 0.80.6",
  "prost",
  "rand_chacha",
  "regex",
@@ -3219,8 +3219,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-asset"
-version = "0.79.4"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.4#2c3e46c3f90afd70a5e70a77fb1044cb1bcc161f"
+version = "0.79.5"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.5#46efbca736ea95d86d40a28b2f77005047ba4c57"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -3233,7 +3233,7 @@ dependencies = [
  "blake2b_simd 1.0.2",
  "bytes",
  "decaf377",
- "decaf377-fmd 0.79.4",
+ "decaf377-fmd 0.79.5",
  "decaf377-rdsa",
  "derivative",
  "ethnum",
@@ -3242,8 +3242,8 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "pbjson-types",
- "penumbra-num 0.79.4",
- "penumbra-proto 0.79.4",
+ "penumbra-num 0.79.5",
+ "penumbra-proto 0.79.5",
  "poseidon377",
  "rand",
  "rand_core",
@@ -3257,8 +3257,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-asset"
-version = "0.80.2"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.80.2#56cb0025e0cece24a6301d72d46bfe7094266daf"
+version = "0.80.6"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.80.6#94b0058158d222f82781d9cbfd98d013d1c16037"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -3271,7 +3271,7 @@ dependencies = [
  "blake2b_simd 1.0.2",
  "bytes",
  "decaf377",
- "decaf377-fmd 0.80.2",
+ "decaf377-fmd 0.80.6",
  "decaf377-rdsa",
  "derivative",
  "ethnum",
@@ -3280,8 +3280,8 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "pbjson-types",
- "penumbra-num 0.80.2",
- "penumbra-proto 0.80.2",
+ "penumbra-num 0.80.6",
+ "penumbra-proto 0.80.6",
  "poseidon377",
  "rand",
  "rand_core",
@@ -3295,8 +3295,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-auction"
-version = "0.79.4"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.4#2c3e46c3f90afd70a5e70a77fb1044cb1bcc161f"
+version = "0.79.5"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.5#46efbca736ea95d86d40a28b2f77005047ba4c57"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -3311,8 +3311,8 @@ dependencies = [
  "bech32",
  "bitvec",
  "blake2b_simd 1.0.2",
- "cnidarium 0.79.4",
- "cnidarium-component 0.79.4",
+ "cnidarium 0.79.5",
+ "cnidarium-component 0.79.5",
  "decaf377",
  "decaf377-rdsa",
  "futures",
@@ -3320,16 +3320,16 @@ dependencies = [
  "metrics",
  "once_cell",
  "pbjson-types",
- "penumbra-asset 0.79.4",
- "penumbra-dex 0.79.4",
- "penumbra-keys 0.79.4",
- "penumbra-num 0.79.4",
- "penumbra-proof-params 0.79.4",
- "penumbra-proto 0.79.4",
- "penumbra-sct 0.79.4",
- "penumbra-shielded-pool 0.79.4",
- "penumbra-tct 0.79.4",
- "penumbra-txhash 0.79.4",
+ "penumbra-asset 0.79.5",
+ "penumbra-dex 0.79.5",
+ "penumbra-keys 0.79.5",
+ "penumbra-num 0.79.5",
+ "penumbra-proof-params 0.79.5",
+ "penumbra-proto 0.79.5",
+ "penumbra-sct 0.79.5",
+ "penumbra-shielded-pool 0.79.5",
+ "penumbra-tct 0.79.5",
+ "penumbra-txhash 0.79.5",
  "prost",
  "prost-types",
  "rand_chacha",
@@ -3347,8 +3347,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-auction"
-version = "0.80.2"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.80.2#56cb0025e0cece24a6301d72d46bfe7094266daf"
+version = "0.80.6"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.80.6#94b0058158d222f82781d9cbfd98d013d1c16037"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -3363,8 +3363,8 @@ dependencies = [
  "bech32",
  "bitvec",
  "blake2b_simd 1.0.2",
- "cnidarium 0.80.2",
- "cnidarium-component 0.80.2",
+ "cnidarium 0.80.6",
+ "cnidarium-component 0.80.6",
  "decaf377",
  "decaf377-rdsa",
  "futures",
@@ -3372,16 +3372,16 @@ dependencies = [
  "metrics",
  "once_cell",
  "pbjson-types",
- "penumbra-asset 0.80.2",
- "penumbra-dex 0.80.2",
- "penumbra-keys 0.80.2",
- "penumbra-num 0.80.2",
- "penumbra-proof-params 0.80.2",
- "penumbra-proto 0.80.2",
- "penumbra-sct 0.80.2",
- "penumbra-shielded-pool 0.80.2",
- "penumbra-tct 0.80.2",
- "penumbra-txhash 0.80.2",
+ "penumbra-asset 0.80.6",
+ "penumbra-dex 0.80.6",
+ "penumbra-keys 0.80.6",
+ "penumbra-num 0.80.6",
+ "penumbra-proof-params 0.80.6",
+ "penumbra-proto 0.80.6",
+ "penumbra-sct 0.80.6",
+ "penumbra-shielded-pool 0.80.6",
+ "penumbra-tct 0.80.6",
+ "penumbra-txhash 0.80.6",
  "prost",
  "prost-types",
  "rand_chacha",
@@ -3399,28 +3399,28 @@ dependencies = [
 
 [[package]]
 name = "penumbra-community-pool"
-version = "0.79.4"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.4#2c3e46c3f90afd70a5e70a77fb1044cb1bcc161f"
+version = "0.79.5"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.5#46efbca736ea95d86d40a28b2f77005047ba4c57"
 dependencies = [
  "anyhow",
  "ark-ff",
  "async-trait",
  "base64 0.21.7",
  "blake2b_simd 1.0.2",
- "cnidarium 0.79.4",
- "cnidarium-component 0.79.4",
+ "cnidarium 0.79.5",
+ "cnidarium-component 0.79.5",
  "futures",
  "hex",
  "metrics",
  "once_cell",
  "pbjson-types",
- "penumbra-asset 0.79.4",
- "penumbra-keys 0.79.4",
- "penumbra-num 0.79.4",
- "penumbra-proto 0.79.4",
- "penumbra-sct 0.79.4",
- "penumbra-shielded-pool 0.79.4",
- "penumbra-txhash 0.79.4",
+ "penumbra-asset 0.79.5",
+ "penumbra-keys 0.79.5",
+ "penumbra-num 0.79.5",
+ "penumbra-proto 0.79.5",
+ "penumbra-sct 0.79.5",
+ "penumbra-shielded-pool 0.79.5",
+ "penumbra-txhash 0.79.5",
  "prost",
  "serde",
  "sha2 0.10.8",
@@ -3431,28 +3431,28 @@ dependencies = [
 
 [[package]]
 name = "penumbra-community-pool"
-version = "0.80.2"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.80.2#56cb0025e0cece24a6301d72d46bfe7094266daf"
+version = "0.80.6"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.80.6#94b0058158d222f82781d9cbfd98d013d1c16037"
 dependencies = [
  "anyhow",
  "ark-ff",
  "async-trait",
  "base64 0.21.7",
  "blake2b_simd 1.0.2",
- "cnidarium 0.80.2",
- "cnidarium-component 0.80.2",
+ "cnidarium 0.80.6",
+ "cnidarium-component 0.80.6",
  "futures",
  "hex",
  "metrics",
  "once_cell",
  "pbjson-types",
- "penumbra-asset 0.80.2",
- "penumbra-keys 0.80.2",
- "penumbra-num 0.80.2",
- "penumbra-proto 0.80.2",
- "penumbra-sct 0.80.2",
- "penumbra-shielded-pool 0.80.2",
- "penumbra-txhash 0.80.2",
+ "penumbra-asset 0.80.6",
+ "penumbra-keys 0.80.6",
+ "penumbra-num 0.80.6",
+ "penumbra-proto 0.80.6",
+ "penumbra-sct 0.80.6",
+ "penumbra-shielded-pool 0.80.6",
+ "penumbra-txhash 0.80.6",
  "prost",
  "serde",
  "sha2 0.10.8",
@@ -3463,30 +3463,30 @@ dependencies = [
 
 [[package]]
 name = "penumbra-compact-block"
-version = "0.79.4"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.4#2c3e46c3f90afd70a5e70a77fb1044cb1bcc161f"
+version = "0.79.5"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.5#46efbca736ea95d86d40a28b2f77005047ba4c57"
 dependencies = [
  "anyhow",
  "ark-ff",
  "async-trait",
  "blake2b_simd 1.0.2",
  "bytes",
- "cnidarium 0.79.4",
- "cnidarium-component 0.79.4",
+ "cnidarium 0.79.5",
+ "cnidarium-component 0.79.5",
  "decaf377-rdsa",
  "futures",
  "im",
  "metrics",
- "penumbra-dex 0.79.4",
- "penumbra-fee 0.79.4",
- "penumbra-governance 0.79.4",
- "penumbra-ibc 0.79.4",
- "penumbra-proof-params 0.79.4",
- "penumbra-proto 0.79.4",
- "penumbra-sct 0.79.4",
- "penumbra-shielded-pool 0.79.4",
- "penumbra-stake 0.79.4",
- "penumbra-tct 0.79.4",
+ "penumbra-dex 0.79.5",
+ "penumbra-fee 0.79.5",
+ "penumbra-governance 0.79.5",
+ "penumbra-ibc 0.79.5",
+ "penumbra-proof-params 0.79.5",
+ "penumbra-proto 0.79.5",
+ "penumbra-sct 0.79.5",
+ "penumbra-shielded-pool 0.79.5",
+ "penumbra-stake 0.79.5",
+ "penumbra-tct 0.79.5",
  "rand",
  "rand_core",
  "serde",
@@ -3499,30 +3499,30 @@ dependencies = [
 
 [[package]]
 name = "penumbra-compact-block"
-version = "0.80.2"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.80.2#56cb0025e0cece24a6301d72d46bfe7094266daf"
+version = "0.80.6"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.80.6#94b0058158d222f82781d9cbfd98d013d1c16037"
 dependencies = [
  "anyhow",
  "ark-ff",
  "async-trait",
  "blake2b_simd 1.0.2",
  "bytes",
- "cnidarium 0.80.2",
- "cnidarium-component 0.80.2",
+ "cnidarium 0.80.6",
+ "cnidarium-component 0.80.6",
  "decaf377-rdsa",
  "futures",
  "im",
  "metrics",
- "penumbra-dex 0.80.2",
- "penumbra-fee 0.80.2",
- "penumbra-governance 0.80.2",
- "penumbra-ibc 0.80.2",
- "penumbra-proof-params 0.80.2",
- "penumbra-proto 0.80.2",
- "penumbra-sct 0.80.2",
- "penumbra-shielded-pool 0.80.2",
- "penumbra-stake 0.80.2",
- "penumbra-tct 0.80.2",
+ "penumbra-dex 0.80.6",
+ "penumbra-fee 0.80.6",
+ "penumbra-governance 0.80.6",
+ "penumbra-ibc 0.80.6",
+ "penumbra-proof-params 0.80.6",
+ "penumbra-proto 0.80.6",
+ "penumbra-sct 0.80.6",
+ "penumbra-shielded-pool 0.80.6",
+ "penumbra-stake 0.80.6",
+ "penumbra-tct 0.80.6",
  "rand",
  "rand_core",
  "serde",
@@ -3535,8 +3535,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-dex"
-version = "0.79.4"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.4#2c3e46c3f90afd70a5e70a77fb1044cb1bcc161f"
+version = "0.79.5"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.5#46efbca736ea95d86d40a28b2f77005047ba4c57"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -3550,11 +3550,11 @@ dependencies = [
  "base64 0.21.7",
  "bincode",
  "blake2b_simd 1.0.2",
- "cnidarium 0.79.4",
- "cnidarium-component 0.79.4",
+ "cnidarium 0.79.5",
+ "cnidarium-component 0.79.5",
  "decaf377",
- "decaf377-fmd 0.79.4",
- "decaf377-ka 0.79.4",
+ "decaf377-fmd 0.79.5",
+ "decaf377-ka 0.79.5",
  "decaf377-rdsa",
  "futures",
  "hex",
@@ -3564,16 +3564,16 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "pbjson-types",
- "penumbra-asset 0.79.4",
- "penumbra-fee 0.79.4",
- "penumbra-keys 0.79.4",
- "penumbra-num 0.79.4",
- "penumbra-proof-params 0.79.4",
- "penumbra-proto 0.79.4",
- "penumbra-sct 0.79.4",
- "penumbra-shielded-pool 0.79.4",
- "penumbra-tct 0.79.4",
- "penumbra-txhash 0.79.4",
+ "penumbra-asset 0.79.5",
+ "penumbra-fee 0.79.5",
+ "penumbra-keys 0.79.5",
+ "penumbra-num 0.79.5",
+ "penumbra-proof-params 0.79.5",
+ "penumbra-proto 0.79.5",
+ "penumbra-sct 0.79.5",
+ "penumbra-shielded-pool 0.79.5",
+ "penumbra-tct 0.79.5",
+ "penumbra-txhash 0.79.5",
  "poseidon377",
  "prost",
  "rand_core",
@@ -3593,8 +3593,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-dex"
-version = "0.80.2"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.80.2#56cb0025e0cece24a6301d72d46bfe7094266daf"
+version = "0.80.6"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.80.6#94b0058158d222f82781d9cbfd98d013d1c16037"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -3608,11 +3608,11 @@ dependencies = [
  "base64 0.21.7",
  "bincode",
  "blake2b_simd 1.0.2",
- "cnidarium 0.80.2",
- "cnidarium-component 0.80.2",
+ "cnidarium 0.80.6",
+ "cnidarium-component 0.80.6",
  "decaf377",
- "decaf377-fmd 0.80.2",
- "decaf377-ka 0.80.2",
+ "decaf377-fmd 0.80.6",
+ "decaf377-ka 0.80.6",
  "decaf377-rdsa",
  "futures",
  "hex",
@@ -3622,16 +3622,16 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "pbjson-types",
- "penumbra-asset 0.80.2",
- "penumbra-fee 0.80.2",
- "penumbra-keys 0.80.2",
- "penumbra-num 0.80.2",
- "penumbra-proof-params 0.80.2",
- "penumbra-proto 0.80.2",
- "penumbra-sct 0.80.2",
- "penumbra-shielded-pool 0.80.2",
- "penumbra-tct 0.80.2",
- "penumbra-txhash 0.80.2",
+ "penumbra-asset 0.80.6",
+ "penumbra-fee 0.80.6",
+ "penumbra-keys 0.80.6",
+ "penumbra-num 0.80.6",
+ "penumbra-proof-params 0.80.6",
+ "penumbra-proto 0.80.6",
+ "penumbra-sct 0.80.6",
+ "penumbra-shielded-pool 0.80.6",
+ "penumbra-tct 0.80.6",
+ "penumbra-txhash 0.80.6",
  "poseidon377",
  "prost",
  "rand_core",
@@ -3651,17 +3651,17 @@ dependencies = [
 
 [[package]]
 name = "penumbra-distributions"
-version = "0.79.4"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.4#2c3e46c3f90afd70a5e70a77fb1044cb1bcc161f"
+version = "0.79.5"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.5#46efbca736ea95d86d40a28b2f77005047ba4c57"
 dependencies = [
  "anyhow",
  "async-trait",
- "cnidarium 0.79.4",
- "cnidarium-component 0.79.4",
- "penumbra-asset 0.79.4",
- "penumbra-num 0.79.4",
- "penumbra-proto 0.79.4",
- "penumbra-sct 0.79.4",
+ "cnidarium 0.79.5",
+ "cnidarium-component 0.79.5",
+ "penumbra-asset 0.79.5",
+ "penumbra-num 0.79.5",
+ "penumbra-proto 0.79.5",
+ "penumbra-sct 0.79.5",
  "serde",
  "tendermint",
  "tracing",
@@ -3669,17 +3669,17 @@ dependencies = [
 
 [[package]]
 name = "penumbra-distributions"
-version = "0.80.2"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.80.2#56cb0025e0cece24a6301d72d46bfe7094266daf"
+version = "0.80.6"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.80.6#94b0058158d222f82781d9cbfd98d013d1c16037"
 dependencies = [
  "anyhow",
  "async-trait",
- "cnidarium 0.80.2",
- "cnidarium-component 0.80.2",
- "penumbra-asset 0.80.2",
- "penumbra-num 0.80.2",
- "penumbra-proto 0.80.2",
- "penumbra-sct 0.80.2",
+ "cnidarium 0.80.6",
+ "cnidarium-component 0.80.6",
+ "penumbra-asset 0.80.6",
+ "penumbra-num 0.80.6",
+ "penumbra-proto 0.80.6",
+ "penumbra-sct 0.80.6",
  "serde",
  "tendermint",
  "tracing",
@@ -3687,23 +3687,23 @@ dependencies = [
 
 [[package]]
 name = "penumbra-fee"
-version = "0.79.4"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.4#2c3e46c3f90afd70a5e70a77fb1044cb1bcc161f"
+version = "0.79.5"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.5#46efbca736ea95d86d40a28b2f77005047ba4c57"
 dependencies = [
  "anyhow",
  "ark-ff",
  "async-trait",
  "blake2b_simd 1.0.2",
  "bytes",
- "cnidarium 0.79.4",
- "cnidarium-component 0.79.4",
+ "cnidarium 0.79.5",
+ "cnidarium-component 0.79.5",
  "decaf377",
  "decaf377-rdsa",
  "im",
  "metrics",
- "penumbra-asset 0.79.4",
- "penumbra-num 0.79.4",
- "penumbra-proto 0.79.4",
+ "penumbra-asset 0.79.5",
+ "penumbra-num 0.79.5",
+ "penumbra-proto 0.79.5",
  "rand",
  "rand_core",
  "serde",
@@ -3714,23 +3714,23 @@ dependencies = [
 
 [[package]]
 name = "penumbra-fee"
-version = "0.80.2"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.80.2#56cb0025e0cece24a6301d72d46bfe7094266daf"
+version = "0.80.6"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.80.6#94b0058158d222f82781d9cbfd98d013d1c16037"
 dependencies = [
  "anyhow",
  "ark-ff",
  "async-trait",
  "blake2b_simd 1.0.2",
  "bytes",
- "cnidarium 0.80.2",
- "cnidarium-component 0.80.2",
+ "cnidarium 0.80.6",
+ "cnidarium-component 0.80.6",
  "decaf377",
  "decaf377-rdsa",
  "im",
  "metrics",
- "penumbra-asset 0.80.2",
- "penumbra-num 0.80.2",
- "penumbra-proto 0.80.2",
+ "penumbra-asset 0.80.6",
+ "penumbra-num 0.80.6",
+ "penumbra-proto 0.80.6",
  "rand",
  "rand_core",
  "serde",
@@ -3741,23 +3741,23 @@ dependencies = [
 
 [[package]]
 name = "penumbra-funding"
-version = "0.79.4"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.4#2c3e46c3f90afd70a5e70a77fb1044cb1bcc161f"
+version = "0.79.5"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.5#46efbca736ea95d86d40a28b2f77005047ba4c57"
 dependencies = [
  "anyhow",
  "async-trait",
- "cnidarium 0.79.4",
- "cnidarium-component 0.79.4",
+ "cnidarium 0.79.5",
+ "cnidarium-component 0.79.5",
  "futures",
  "metrics",
- "penumbra-asset 0.79.4",
- "penumbra-community-pool 0.79.4",
- "penumbra-distributions 0.79.4",
- "penumbra-num 0.79.4",
- "penumbra-proto 0.79.4",
- "penumbra-sct 0.79.4",
- "penumbra-shielded-pool 0.79.4",
- "penumbra-stake 0.79.4",
+ "penumbra-asset 0.79.5",
+ "penumbra-community-pool 0.79.5",
+ "penumbra-distributions 0.79.5",
+ "penumbra-num 0.79.5",
+ "penumbra-proto 0.79.5",
+ "penumbra-sct 0.79.5",
+ "penumbra-shielded-pool 0.79.5",
+ "penumbra-stake 0.79.5",
  "serde",
  "tendermint",
  "tracing",
@@ -3765,23 +3765,23 @@ dependencies = [
 
 [[package]]
 name = "penumbra-funding"
-version = "0.80.2"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.80.2#56cb0025e0cece24a6301d72d46bfe7094266daf"
+version = "0.80.6"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.80.6#94b0058158d222f82781d9cbfd98d013d1c16037"
 dependencies = [
  "anyhow",
  "async-trait",
- "cnidarium 0.80.2",
- "cnidarium-component 0.80.2",
+ "cnidarium 0.80.6",
+ "cnidarium-component 0.80.6",
  "futures",
  "metrics",
- "penumbra-asset 0.80.2",
- "penumbra-community-pool 0.80.2",
- "penumbra-distributions 0.80.2",
- "penumbra-num 0.80.2",
- "penumbra-proto 0.80.2",
- "penumbra-sct 0.80.2",
- "penumbra-shielded-pool 0.80.2",
- "penumbra-stake 0.80.2",
+ "penumbra-asset 0.80.6",
+ "penumbra-community-pool 0.80.6",
+ "penumbra-distributions 0.80.6",
+ "penumbra-num 0.80.6",
+ "penumbra-proto 0.80.6",
+ "penumbra-sct 0.80.6",
+ "penumbra-shielded-pool 0.80.6",
+ "penumbra-stake 0.80.6",
  "serde",
  "tendermint",
  "tracing",
@@ -3789,8 +3789,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-governance"
-version = "0.79.4"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.4#2c3e46c3f90afd70a5e70a77fb1044cb1bcc161f"
+version = "0.79.5"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.5#46efbca736ea95d86d40a28b2f77005047ba4c57"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -3804,8 +3804,8 @@ dependencies = [
  "base64 0.21.7",
  "blake2b_simd 1.0.2",
  "bytes",
- "cnidarium 0.79.4",
- "cnidarium-component 0.79.4",
+ "cnidarium 0.79.5",
+ "cnidarium-component 0.79.5",
  "decaf377",
  "decaf377-rdsa",
  "futures",
@@ -3814,18 +3814,18 @@ dependencies = [
  "metrics",
  "once_cell",
  "pbjson-types",
- "penumbra-asset 0.79.4",
- "penumbra-distributions 0.79.4",
- "penumbra-ibc 0.79.4",
- "penumbra-keys 0.79.4",
- "penumbra-num 0.79.4",
- "penumbra-proof-params 0.79.4",
- "penumbra-proto 0.79.4",
- "penumbra-sct 0.79.4",
- "penumbra-shielded-pool 0.79.4",
- "penumbra-stake 0.79.4",
- "penumbra-tct 0.79.4",
- "penumbra-txhash 0.79.4",
+ "penumbra-asset 0.79.5",
+ "penumbra-distributions 0.79.5",
+ "penumbra-ibc 0.79.5",
+ "penumbra-keys 0.79.5",
+ "penumbra-num 0.79.5",
+ "penumbra-proof-params 0.79.5",
+ "penumbra-proto 0.79.5",
+ "penumbra-sct 0.79.5",
+ "penumbra-shielded-pool 0.79.5",
+ "penumbra-stake 0.79.5",
+ "penumbra-tct 0.79.5",
+ "penumbra-txhash 0.79.5",
  "rand",
  "rand_chacha",
  "rand_core",
@@ -3842,8 +3842,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-governance"
-version = "0.80.2"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.80.2#56cb0025e0cece24a6301d72d46bfe7094266daf"
+version = "0.80.6"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.80.6#94b0058158d222f82781d9cbfd98d013d1c16037"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -3857,8 +3857,8 @@ dependencies = [
  "base64 0.21.7",
  "blake2b_simd 1.0.2",
  "bytes",
- "cnidarium 0.80.2",
- "cnidarium-component 0.80.2",
+ "cnidarium 0.80.6",
+ "cnidarium-component 0.80.6",
  "decaf377",
  "decaf377-rdsa",
  "futures",
@@ -3867,18 +3867,18 @@ dependencies = [
  "metrics",
  "once_cell",
  "pbjson-types",
- "penumbra-asset 0.80.2",
- "penumbra-distributions 0.80.2",
- "penumbra-ibc 0.80.2",
- "penumbra-keys 0.80.2",
- "penumbra-num 0.80.2",
- "penumbra-proof-params 0.80.2",
- "penumbra-proto 0.80.2",
- "penumbra-sct 0.80.2",
- "penumbra-shielded-pool 0.80.2",
- "penumbra-stake 0.80.2",
- "penumbra-tct 0.80.2",
- "penumbra-txhash 0.80.2",
+ "penumbra-asset 0.80.6",
+ "penumbra-distributions 0.80.6",
+ "penumbra-ibc 0.80.6",
+ "penumbra-keys 0.80.6",
+ "penumbra-num 0.80.6",
+ "penumbra-proof-params 0.80.6",
+ "penumbra-proto 0.80.6",
+ "penumbra-sct 0.80.6",
+ "penumbra-shielded-pool 0.80.6",
+ "penumbra-stake 0.80.6",
+ "penumbra-tct 0.80.6",
+ "penumbra-txhash 0.80.6",
  "rand",
  "rand_chacha",
  "rand_core",
@@ -3895,15 +3895,15 @@ dependencies = [
 
 [[package]]
 name = "penumbra-ibc"
-version = "0.79.4"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.4#2c3e46c3f90afd70a5e70a77fb1044cb1bcc161f"
+version = "0.79.5"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.5#46efbca736ea95d86d40a28b2f77005047ba4c57"
 dependencies = [
  "anyhow",
  "ark-ff",
  "async-trait",
  "base64 0.21.7",
  "blake2b_simd 1.0.2",
- "cnidarium 0.79.4",
+ "cnidarium 0.79.5",
  "futures",
  "hex",
  "ibc-proto",
@@ -3913,11 +3913,11 @@ dependencies = [
  "num-traits",
  "once_cell",
  "pbjson-types",
- "penumbra-asset 0.79.4",
- "penumbra-num 0.79.4",
- "penumbra-proto 0.79.4",
- "penumbra-sct 0.79.4",
- "penumbra-txhash 0.79.4",
+ "penumbra-asset 0.79.5",
+ "penumbra-num 0.79.5",
+ "penumbra-proto 0.79.5",
+ "penumbra-sct 0.79.5",
+ "penumbra-txhash 0.79.5",
  "prost",
  "serde",
  "serde_json",
@@ -3932,15 +3932,15 @@ dependencies = [
 
 [[package]]
 name = "penumbra-ibc"
-version = "0.80.2"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.80.2#56cb0025e0cece24a6301d72d46bfe7094266daf"
+version = "0.80.6"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.80.6#94b0058158d222f82781d9cbfd98d013d1c16037"
 dependencies = [
  "anyhow",
  "ark-ff",
  "async-trait",
  "base64 0.21.7",
  "blake2b_simd 1.0.2",
- "cnidarium 0.80.2",
+ "cnidarium 0.80.6",
  "futures",
  "hex",
  "ibc-proto",
@@ -3950,11 +3950,11 @@ dependencies = [
  "num-traits",
  "once_cell",
  "pbjson-types",
- "penumbra-asset 0.80.2",
- "penumbra-num 0.80.2",
- "penumbra-proto 0.80.2",
- "penumbra-sct 0.80.2",
- "penumbra-txhash 0.80.2",
+ "penumbra-asset 0.80.6",
+ "penumbra-num 0.80.6",
+ "penumbra-proto 0.80.6",
+ "penumbra-sct 0.80.6",
+ "penumbra-txhash 0.80.6",
  "prost",
  "serde",
  "serde_json",
@@ -3969,8 +3969,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-keys"
-version = "0.79.4"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.4#2c3e46c3f90afd70a5e70a77fb1044cb1bcc161f"
+version = "0.79.5"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.5#46efbca736ea95d86d40a28b2f77005047ba4c57"
 dependencies = [
  "aes",
  "anyhow",
@@ -3986,8 +3986,8 @@ dependencies = [
  "bytes",
  "chacha20poly1305",
  "decaf377",
- "decaf377-fmd 0.79.4",
- "decaf377-ka 0.79.4",
+ "decaf377-fmd 0.79.5",
+ "decaf377-ka 0.79.5",
  "decaf377-rdsa",
  "derivative",
  "ethnum",
@@ -3998,9 +3998,9 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "pbkdf2",
- "penumbra-asset 0.79.4",
- "penumbra-proto 0.79.4",
- "penumbra-tct 0.79.4",
+ "penumbra-asset 0.79.5",
+ "penumbra-proto 0.79.5",
+ "penumbra-tct 0.79.5",
  "poseidon377",
  "rand",
  "rand_core",
@@ -4013,8 +4013,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-keys"
-version = "0.80.2"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.80.2#56cb0025e0cece24a6301d72d46bfe7094266daf"
+version = "0.80.6"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.80.6#94b0058158d222f82781d9cbfd98d013d1c16037"
 dependencies = [
  "aes",
  "anyhow",
@@ -4030,8 +4030,8 @@ dependencies = [
  "bytes",
  "chacha20poly1305",
  "decaf377",
- "decaf377-fmd 0.80.2",
- "decaf377-ka 0.80.2",
+ "decaf377-fmd 0.80.6",
+ "decaf377-ka 0.80.6",
  "decaf377-rdsa",
  "derivative",
  "ethnum",
@@ -4042,9 +4042,9 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "pbkdf2",
- "penumbra-asset 0.80.2",
- "penumbra-proto 0.80.2",
- "penumbra-tct 0.80.2",
+ "penumbra-asset 0.80.6",
+ "penumbra-proto 0.80.6",
+ "penumbra-tct 0.80.6",
  "poseidon377",
  "rand",
  "rand_core",
@@ -4057,8 +4057,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-num"
-version = "0.79.4"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.4#2c3e46c3f90afd70a5e70a77fb1044cb1bcc161f"
+version = "0.79.5"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.5#46efbca736ea95d86d40a28b2f77005047ba4c57"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -4073,7 +4073,7 @@ dependencies = [
  "blake2b_simd 1.0.2",
  "bytes",
  "decaf377",
- "decaf377-fmd 0.79.4",
+ "decaf377-fmd 0.79.5",
  "decaf377-rdsa",
  "derivative",
  "ethnum",
@@ -4081,7 +4081,7 @@ dependencies = [
  "ibig",
  "num-bigint",
  "once_cell",
- "penumbra-proto 0.79.4",
+ "penumbra-proto 0.79.5",
  "rand",
  "rand_core",
  "regex",
@@ -4093,8 +4093,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-num"
-version = "0.80.2"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.80.2#56cb0025e0cece24a6301d72d46bfe7094266daf"
+version = "0.80.6"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.80.6#94b0058158d222f82781d9cbfd98d013d1c16037"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -4109,7 +4109,7 @@ dependencies = [
  "blake2b_simd 1.0.2",
  "bytes",
  "decaf377",
- "decaf377-fmd 0.80.2",
+ "decaf377-fmd 0.80.6",
  "decaf377-rdsa",
  "derivative",
  "ethnum",
@@ -4117,7 +4117,7 @@ dependencies = [
  "ibig",
  "num-bigint",
  "once_cell",
- "penumbra-proto 0.80.2",
+ "penumbra-proto 0.80.6",
  "rand",
  "rand_core",
  "regex",
@@ -4129,8 +4129,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-proof-params"
-version = "0.79.4"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.4#2c3e46c3f90afd70a5e70a77fb1044cb1bcc161f"
+version = "0.79.5"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.5#46efbca736ea95d86d40a28b2f77005047ba4c57"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -4155,8 +4155,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-proof-params"
-version = "0.80.2"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.80.2#56cb0025e0cece24a6301d72d46bfe7094266daf"
+version = "0.80.6"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.80.6#94b0058158d222f82781d9cbfd98d013d1c16037"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -4180,16 +4180,16 @@ dependencies = [
 
 [[package]]
 name = "penumbra-proto"
-version = "0.79.4"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.4#2c3e46c3f90afd70a5e70a77fb1044cb1bcc161f"
+version = "0.79.5"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.5#46efbca736ea95d86d40a28b2f77005047ba4c57"
 dependencies = [
  "anyhow",
  "async-trait",
  "bech32",
  "bytes",
  "chrono",
- "cnidarium 0.79.4",
- "decaf377-fmd 0.79.4",
+ "cnidarium 0.79.5",
+ "decaf377-fmd 0.79.5",
  "decaf377-rdsa",
  "futures",
  "hex",
@@ -4213,16 +4213,16 @@ dependencies = [
 
 [[package]]
 name = "penumbra-proto"
-version = "0.80.2"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.80.2#56cb0025e0cece24a6301d72d46bfe7094266daf"
+version = "0.80.6"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.80.6#94b0058158d222f82781d9cbfd98d013d1c16037"
 dependencies = [
  "anyhow",
  "async-trait",
  "bech32",
  "bytes",
  "chrono",
- "cnidarium 0.80.2",
- "decaf377-fmd 0.80.2",
+ "cnidarium 0.80.6",
+ "decaf377-fmd 0.80.6",
  "decaf377-rdsa",
  "futures",
  "hex",
@@ -4251,19 +4251,19 @@ dependencies = [
  "anyhow",
  "async-trait",
  "clap",
- "cnidarium 0.79.4",
- "cnidarium 0.80.2",
+ "cnidarium 0.79.5",
+ "cnidarium 0.80.6",
  "directories",
  "hex",
  "ibc-types",
- "penumbra-app 0.79.4",
- "penumbra-app 0.80.2",
- "penumbra-governance 0.80.2",
- "penumbra-ibc 0.79.4",
- "penumbra-ibc 0.80.2",
- "penumbra-proto 0.80.2",
- "penumbra-sct 0.80.2",
- "penumbra-transaction 0.80.2",
+ "penumbra-app 0.79.5",
+ "penumbra-app 0.80.6",
+ "penumbra-governance 0.80.6",
+ "penumbra-ibc 0.79.5",
+ "penumbra-ibc 0.80.6",
+ "penumbra-proto 0.80.6",
+ "penumbra-sct 0.80.6",
+ "penumbra-transaction 0.80.6",
  "serde_json",
  "sqlx",
  "tendermint",
@@ -4276,8 +4276,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sct"
-version = "0.79.4"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.4#2c3e46c3f90afd70a5e70a77fb1044cb1bcc161f"
+version = "0.79.5"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.5#46efbca736ea95d86d40a28b2f77005047ba4c57"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -4289,8 +4289,8 @@ dependencies = [
  "blake2b_simd 1.0.2",
  "bytes",
  "chrono",
- "cnidarium 0.79.4",
- "cnidarium-component 0.79.4",
+ "cnidarium 0.79.5",
+ "cnidarium-component 0.79.5",
  "decaf377",
  "decaf377-rdsa",
  "hex",
@@ -4298,9 +4298,9 @@ dependencies = [
  "metrics",
  "once_cell",
  "pbjson-types",
- "penumbra-keys 0.79.4",
- "penumbra-proto 0.79.4",
- "penumbra-tct 0.79.4",
+ "penumbra-keys 0.79.5",
+ "penumbra-proto 0.79.5",
+ "penumbra-tct 0.79.5",
  "poseidon377",
  "rand",
  "rand_core",
@@ -4312,8 +4312,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sct"
-version = "0.80.2"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.80.2#56cb0025e0cece24a6301d72d46bfe7094266daf"
+version = "0.80.6"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.80.6#94b0058158d222f82781d9cbfd98d013d1c16037"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -4325,8 +4325,8 @@ dependencies = [
  "blake2b_simd 1.0.2",
  "bytes",
  "chrono",
- "cnidarium 0.80.2",
- "cnidarium-component 0.80.2",
+ "cnidarium 0.80.6",
+ "cnidarium-component 0.80.6",
  "decaf377",
  "decaf377-rdsa",
  "hex",
@@ -4334,9 +4334,9 @@ dependencies = [
  "metrics",
  "once_cell",
  "pbjson-types",
- "penumbra-keys 0.80.2",
- "penumbra-proto 0.80.2",
- "penumbra-tct 0.80.2",
+ "penumbra-keys 0.80.6",
+ "penumbra-proto 0.80.6",
+ "penumbra-tct 0.80.6",
  "poseidon377",
  "rand",
  "rand_core",
@@ -4348,8 +4348,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-shielded-pool"
-version = "0.79.4"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.4#2c3e46c3f90afd70a5e70a77fb1044cb1bcc161f"
+version = "0.79.5"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.5#46efbca736ea95d86d40a28b2f77005047ba4c57"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -4364,11 +4364,11 @@ dependencies = [
  "blake2b_simd 1.0.2",
  "bytes",
  "chacha20poly1305",
- "cnidarium 0.79.4",
- "cnidarium-component 0.79.4",
+ "cnidarium 0.79.5",
+ "cnidarium-component 0.79.5",
  "decaf377",
- "decaf377-fmd 0.79.4",
- "decaf377-ka 0.79.4",
+ "decaf377-fmd 0.79.5",
+ "decaf377-ka 0.79.5",
  "decaf377-rdsa",
  "futures",
  "hex",
@@ -4377,15 +4377,15 @@ dependencies = [
  "im",
  "metrics",
  "once_cell",
- "penumbra-asset 0.79.4",
- "penumbra-ibc 0.79.4",
- "penumbra-keys 0.79.4",
- "penumbra-num 0.79.4",
- "penumbra-proof-params 0.79.4",
- "penumbra-proto 0.79.4",
- "penumbra-sct 0.79.4",
- "penumbra-tct 0.79.4",
- "penumbra-txhash 0.79.4",
+ "penumbra-asset 0.79.5",
+ "penumbra-ibc 0.79.5",
+ "penumbra-keys 0.79.5",
+ "penumbra-num 0.79.5",
+ "penumbra-proof-params 0.79.5",
+ "penumbra-proto 0.79.5",
+ "penumbra-sct 0.79.5",
+ "penumbra-tct 0.79.5",
+ "penumbra-txhash 0.79.5",
  "poseidon377",
  "prost",
  "rand",
@@ -4402,8 +4402,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-shielded-pool"
-version = "0.80.2"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.80.2#56cb0025e0cece24a6301d72d46bfe7094266daf"
+version = "0.80.6"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.80.6#94b0058158d222f82781d9cbfd98d013d1c16037"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -4418,11 +4418,11 @@ dependencies = [
  "blake2b_simd 1.0.2",
  "bytes",
  "chacha20poly1305",
- "cnidarium 0.80.2",
- "cnidarium-component 0.80.2",
+ "cnidarium 0.80.6",
+ "cnidarium-component 0.80.6",
  "decaf377",
- "decaf377-fmd 0.80.2",
- "decaf377-ka 0.80.2",
+ "decaf377-fmd 0.80.6",
+ "decaf377-ka 0.80.6",
  "decaf377-rdsa",
  "futures",
  "hex",
@@ -4431,15 +4431,15 @@ dependencies = [
  "im",
  "metrics",
  "once_cell",
- "penumbra-asset 0.80.2",
- "penumbra-ibc 0.80.2",
- "penumbra-keys 0.80.2",
- "penumbra-num 0.80.2",
- "penumbra-proof-params 0.80.2",
- "penumbra-proto 0.80.2",
- "penumbra-sct 0.80.2",
- "penumbra-tct 0.80.2",
- "penumbra-txhash 0.80.2",
+ "penumbra-asset 0.80.6",
+ "penumbra-ibc 0.80.6",
+ "penumbra-keys 0.80.6",
+ "penumbra-num 0.80.6",
+ "penumbra-proof-params 0.80.6",
+ "penumbra-proto 0.80.6",
+ "penumbra-sct 0.80.6",
+ "penumbra-tct 0.80.6",
+ "penumbra-txhash 0.80.6",
  "poseidon377",
  "prost",
  "rand",
@@ -4456,8 +4456,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-stake"
-version = "0.79.4"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.4#2c3e46c3f90afd70a5e70a77fb1044cb1bcc161f"
+version = "0.79.5"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.5#46efbca736ea95d86d40a28b2f77005047ba4c57"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -4471,8 +4471,8 @@ dependencies = [
  "base64 0.21.7",
  "bech32",
  "bitvec",
- "cnidarium 0.79.4",
- "cnidarium-component 0.79.4",
+ "cnidarium 0.79.5",
+ "cnidarium-component 0.79.5",
  "decaf377",
  "decaf377-rdsa",
  "futures",
@@ -4480,16 +4480,16 @@ dependencies = [
  "im",
  "metrics",
  "once_cell",
- "penumbra-asset 0.79.4",
- "penumbra-distributions 0.79.4",
- "penumbra-keys 0.79.4",
- "penumbra-num 0.79.4",
- "penumbra-proof-params 0.79.4",
- "penumbra-proto 0.79.4",
- "penumbra-sct 0.79.4",
- "penumbra-shielded-pool 0.79.4",
- "penumbra-tct 0.79.4",
- "penumbra-txhash 0.79.4",
+ "penumbra-asset 0.79.5",
+ "penumbra-distributions 0.79.5",
+ "penumbra-keys 0.79.5",
+ "penumbra-num 0.79.5",
+ "penumbra-proof-params 0.79.5",
+ "penumbra-proto 0.79.5",
+ "penumbra-sct 0.79.5",
+ "penumbra-shielded-pool 0.79.5",
+ "penumbra-tct 0.79.5",
+ "penumbra-txhash 0.79.5",
  "rand_chacha",
  "rand_core",
  "regex",
@@ -4506,8 +4506,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-stake"
-version = "0.80.2"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.80.2#56cb0025e0cece24a6301d72d46bfe7094266daf"
+version = "0.80.6"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.80.6#94b0058158d222f82781d9cbfd98d013d1c16037"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -4521,8 +4521,8 @@ dependencies = [
  "base64 0.21.7",
  "bech32",
  "bitvec",
- "cnidarium 0.80.2",
- "cnidarium-component 0.80.2",
+ "cnidarium 0.80.6",
+ "cnidarium-component 0.80.6",
  "decaf377",
  "decaf377-rdsa",
  "futures",
@@ -4530,16 +4530,16 @@ dependencies = [
  "im",
  "metrics",
  "once_cell",
- "penumbra-asset 0.80.2",
- "penumbra-distributions 0.80.2",
- "penumbra-keys 0.80.2",
- "penumbra-num 0.80.2",
- "penumbra-proof-params 0.80.2",
- "penumbra-proto 0.80.2",
- "penumbra-sct 0.80.2",
- "penumbra-shielded-pool 0.80.2",
- "penumbra-tct 0.80.2",
- "penumbra-txhash 0.80.2",
+ "penumbra-asset 0.80.6",
+ "penumbra-distributions 0.80.6",
+ "penumbra-keys 0.80.6",
+ "penumbra-num 0.80.6",
+ "penumbra-proof-params 0.80.6",
+ "penumbra-proto 0.80.6",
+ "penumbra-sct 0.80.6",
+ "penumbra-shielded-pool 0.80.6",
+ "penumbra-tct 0.80.6",
+ "penumbra-txhash 0.80.6",
  "rand_chacha",
  "rand_core",
  "regex",
@@ -4556,8 +4556,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-tct"
-version = "0.79.4"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.4#2c3e46c3f90afd70a5e70a77fb1044cb1bcc161f"
+version = "0.79.5"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.5#46efbca736ea95d86d40a28b2f77005047ba4c57"
 dependencies = [
  "ark-ed-on-bls12-377",
  "ark-ff",
@@ -4574,7 +4574,7 @@ dependencies = [
  "im",
  "once_cell",
  "parking_lot",
- "penumbra-proto 0.79.4",
+ "penumbra-proto 0.79.5",
  "poseidon377",
  "rand",
  "serde",
@@ -4584,8 +4584,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-tct"
-version = "0.80.2"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.80.2#56cb0025e0cece24a6301d72d46bfe7094266daf"
+version = "0.80.6"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.80.6#94b0058158d222f82781d9cbfd98d013d1c16037"
 dependencies = [
  "ark-ed-on-bls12-377",
  "ark-ff",
@@ -4602,7 +4602,7 @@ dependencies = [
  "im",
  "once_cell",
  "parking_lot",
- "penumbra-proto 0.80.2",
+ "penumbra-proto 0.80.6",
  "poseidon377",
  "rand",
  "serde",
@@ -4612,8 +4612,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-tendermint-proxy"
-version = "0.79.4"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.4#2c3e46c3f90afd70a5e70a77fb1044cb1bcc161f"
+version = "0.79.5"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.5#46efbca736ea95d86d40a28b2f77005047ba4c57"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4622,8 +4622,8 @@ dependencies = [
  "http",
  "metrics",
  "pbjson-types",
- "penumbra-proto 0.79.4",
- "penumbra-transaction 0.79.4",
+ "penumbra-proto 0.79.5",
+ "penumbra-transaction 0.79.5",
  "pin-project",
  "pin-project-lite",
  "sha2 0.10.8",
@@ -4645,8 +4645,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-test-subscriber"
-version = "0.79.4"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.4#2c3e46c3f90afd70a5e70a77fb1044cb1bcc161f"
+version = "0.79.5"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.5#46efbca736ea95d86d40a28b2f77005047ba4c57"
 dependencies = [
  "tracing",
  "tracing-subscriber 0.3.18",
@@ -4654,8 +4654,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-test-subscriber"
-version = "0.80.2"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.80.2#56cb0025e0cece24a6301d72d46bfe7094266daf"
+version = "0.80.6"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.80.6#94b0058158d222f82781d9cbfd98d013d1c16037"
 dependencies = [
  "tracing",
  "tracing-subscriber 0.3.18",
@@ -4663,8 +4663,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-tower-trace"
-version = "0.79.4"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.4#2c3e46c3f90afd70a5e70a77fb1044cb1bcc161f"
+version = "0.79.5"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.5#46efbca736ea95d86d40a28b2f77005047ba4c57"
 dependencies = [
  "futures",
  "hex",
@@ -4685,8 +4685,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-tower-trace"
-version = "0.80.2"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.80.2#56cb0025e0cece24a6301d72d46bfe7094266daf"
+version = "0.80.6"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.80.6#94b0058158d222f82781d9cbfd98d013d1c16037"
 dependencies = [
  "futures",
  "hex",
@@ -4707,8 +4707,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-transaction"
-version = "0.79.4"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.4#2c3e46c3f90afd70a5e70a77fb1044cb1bcc161f"
+version = "0.79.5"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.5#46efbca736ea95d86d40a28b2f77005047ba4c57"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -4719,8 +4719,8 @@ dependencies = [
  "bytes",
  "chacha20poly1305",
  "decaf377",
- "decaf377-fmd 0.79.4",
- "decaf377-ka 0.79.4",
+ "decaf377-fmd 0.79.5",
+ "decaf377-ka 0.79.5",
  "decaf377-rdsa",
  "derivative",
  "hex",
@@ -4729,22 +4729,22 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "pbjson-types",
- "penumbra-asset 0.79.4",
- "penumbra-auction 0.79.4",
- "penumbra-community-pool 0.79.4",
- "penumbra-dex 0.79.4",
- "penumbra-fee 0.79.4",
- "penumbra-governance 0.79.4",
- "penumbra-ibc 0.79.4",
- "penumbra-keys 0.79.4",
- "penumbra-num 0.79.4",
- "penumbra-proof-params 0.79.4",
- "penumbra-proto 0.79.4",
- "penumbra-sct 0.79.4",
- "penumbra-shielded-pool 0.79.4",
- "penumbra-stake 0.79.4",
- "penumbra-tct 0.79.4",
- "penumbra-txhash 0.79.4",
+ "penumbra-asset 0.79.5",
+ "penumbra-auction 0.79.5",
+ "penumbra-community-pool 0.79.5",
+ "penumbra-dex 0.79.5",
+ "penumbra-fee 0.79.5",
+ "penumbra-governance 0.79.5",
+ "penumbra-ibc 0.79.5",
+ "penumbra-keys 0.79.5",
+ "penumbra-num 0.79.5",
+ "penumbra-proof-params 0.79.5",
+ "penumbra-proto 0.79.5",
+ "penumbra-sct 0.79.5",
+ "penumbra-shielded-pool 0.79.5",
+ "penumbra-stake 0.79.5",
+ "penumbra-tct 0.79.5",
+ "penumbra-txhash 0.79.5",
  "poseidon377",
  "rand",
  "rand_core",
@@ -4759,8 +4759,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-transaction"
-version = "0.80.2"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.80.2#56cb0025e0cece24a6301d72d46bfe7094266daf"
+version = "0.80.6"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.80.6#94b0058158d222f82781d9cbfd98d013d1c16037"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -4771,8 +4771,8 @@ dependencies = [
  "bytes",
  "chacha20poly1305",
  "decaf377",
- "decaf377-fmd 0.80.2",
- "decaf377-ka 0.80.2",
+ "decaf377-fmd 0.80.6",
+ "decaf377-ka 0.80.6",
  "decaf377-rdsa",
  "derivative",
  "hex",
@@ -4781,22 +4781,22 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "pbjson-types",
- "penumbra-asset 0.80.2",
- "penumbra-auction 0.80.2",
- "penumbra-community-pool 0.80.2",
- "penumbra-dex 0.80.2",
- "penumbra-fee 0.80.2",
- "penumbra-governance 0.80.2",
- "penumbra-ibc 0.80.2",
- "penumbra-keys 0.80.2",
- "penumbra-num 0.80.2",
- "penumbra-proof-params 0.80.2",
- "penumbra-proto 0.80.2",
- "penumbra-sct 0.80.2",
- "penumbra-shielded-pool 0.80.2",
- "penumbra-stake 0.80.2",
- "penumbra-tct 0.80.2",
- "penumbra-txhash 0.80.2",
+ "penumbra-asset 0.80.6",
+ "penumbra-auction 0.80.6",
+ "penumbra-community-pool 0.80.6",
+ "penumbra-dex 0.80.6",
+ "penumbra-fee 0.80.6",
+ "penumbra-governance 0.80.6",
+ "penumbra-ibc 0.80.6",
+ "penumbra-keys 0.80.6",
+ "penumbra-num 0.80.6",
+ "penumbra-proof-params 0.80.6",
+ "penumbra-proto 0.80.6",
+ "penumbra-sct 0.80.6",
+ "penumbra-shielded-pool 0.80.6",
+ "penumbra-stake 0.80.6",
+ "penumbra-tct 0.80.6",
+ "penumbra-txhash 0.80.6",
  "poseidon377",
  "rand",
  "rand_core",
@@ -4811,29 +4811,29 @@ dependencies = [
 
 [[package]]
 name = "penumbra-txhash"
-version = "0.79.4"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.4#2c3e46c3f90afd70a5e70a77fb1044cb1bcc161f"
+version = "0.79.5"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.5#46efbca736ea95d86d40a28b2f77005047ba4c57"
 dependencies = [
  "anyhow",
  "blake2b_simd 1.0.2",
  "getrandom",
  "hex",
- "penumbra-proto 0.79.4",
- "penumbra-tct 0.79.4",
+ "penumbra-proto 0.79.5",
+ "penumbra-tct 0.79.5",
  "serde",
 ]
 
 [[package]]
 name = "penumbra-txhash"
-version = "0.80.2"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.80.2#56cb0025e0cece24a6301d72d46bfe7094266daf"
+version = "0.80.6"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.80.6#94b0058158d222f82781d9cbfd98d013d1c16037"
 dependencies = [
  "anyhow",
  "blake2b_simd 1.0.2",
  "getrandom",
  "hex",
- "penumbra-proto 0.80.2",
- "penumbra-tct 0.80.2",
+ "penumbra-proto 0.80.6",
+ "penumbra-tct 0.80.6",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,28 +13,29 @@ anyhow = "1"
 async-trait = "0.1.81"
 clap = { version = "4", features = ["derive"] }
 directories = "5.0.1"
+hex = "0.4.3"
 ibc-types = "0.12.0"
-penumbra-proto = { git = "https://github.com/penumbra-zone/penumbra", tag = "v0.80.2", features = ["tendermint"] } 
-tendermint = { version = "0.34.0", default-features = false }
-tendermint-proto = { version = "0.34.0", default-features = false }
+penumbra-proto = { git = "https://github.com/penumbra-zone/penumbra", features = ["tendermint"], tag = "v0.80.6" }
 serde_json = "1.0.125"
 sqlx = { version = "0.8.0", features = ["runtime-tokio", "sqlite", "postgres"] }
+tendermint = { version = "0.34.0", default-features = false }
+tendermint-proto = { version = "0.34.0", default-features = false }
 tokio = { version = "1.39.3", features = ["rt"] }
 toml = "0.8.19"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
+
 # V0.79 dependencies
-cnidarium-v0o79 = { package = "cnidarium", git = "https://github.com/penumbra-zone/penumbra", tag = "v0.79.4" } 
-penumbra-app-v0o79 = { package = "penumbra-app", git = "https://github.com/penumbra-zone/penumbra", tag = "v0.79.4" } 
-penumbra-ibc-v0o79 = { package = "penumbra-ibc", git = "https://github.com/penumbra-zone/penumbra", tag = "v0.79.4" } 
+cnidarium-v0o79 = { package = "cnidarium", git = "https://github.com/penumbra-zone/penumbra", tag = "v0.79.5" }
+penumbra-app-v0o79 = { package = "penumbra-app", git = "https://github.com/penumbra-zone/penumbra", tag = "v0.79.5" }
+penumbra-ibc-v0o79 = { package = "penumbra-ibc", git = "https://github.com/penumbra-zone/penumbra", tag = "v0.79.5" }
 # V0.80 dependencies
-cnidarium-v0o80 = { package = "cnidarium", git = "https://github.com/penumbra-zone/penumbra", tag = "v0.80.2" } 
-penumbra-app-v0o80 = { package = "penumbra-app", git = "https://github.com/penumbra-zone/penumbra", tag = "v0.80.2" } 
-penumbra-governance-v0o80 = { package = "penumbra-governance", git = "https://github.com/penumbra-zone/penumbra", tag = "v0.80.2" } 
-penumbra-ibc-v0o80 = { package = "penumbra-ibc", git = "https://github.com/penumbra-zone/penumbra", tag = "v0.80.2" } 
-penumbra-transaction-v0o80 = { package = "penumbra-transaction", git = "https://github.com/penumbra-zone/penumbra", tag = "v0.80.2" } 
-penumbra-sct-v0o80 = { package = "penumbra-sct", git = "https://github.com/penumbra-zone/penumbra", tag = "v0.80.2" } 
-hex = "0.4.3"
+cnidarium-v0o80 = { package = "cnidarium", git = "https://github.com/penumbra-zone/penumbra", tag = "v0.80.6" }
+penumbra-app-v0o80 = { package = "penumbra-app", git = "https://github.com/penumbra-zone/penumbra", tag = "v0.80.6" }
+penumbra-governance-v0o80 = { package = "penumbra-governance", git = "https://github.com/penumbra-zone/penumbra", tag = "v0.80.6" }
+penumbra-ibc-v0o80 = { package = "penumbra-ibc", git = "https://github.com/penumbra-zone/penumbra", tag = "v0.80.6" }
+penumbra-sct-v0o80 = { package = "penumbra-sct", git = "https://github.com/penumbra-zone/penumbra", tag = "v0.80.6" }
+penumbra-transaction-v0o80 = { package = "penumbra-transaction", git = "https://github.com/penumbra-zone/penumbra", tag = "v0.80.6" }
 
 
 # In debug builds, nonetheless compile dependencies in release mode, for performance.


### PR DESCRIPTION
For the v0.80.x release series, we're now on `v0.80.6`, and for v0.79.x, bumped to `v0.79.5`. See corresponding release issues:

  * https://github.com/penumbra-zone/penumbra/issues/4882
  * https://github.com/penumbra-zone/penumbra/issues/4876

I also sorted the deps to make them a bit more readable and easier to manage.