### PR TITLE
build: support 'nix build' for cometbft archive

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,63 @@
+# Workflow file to validate that builds work.
+# Normally we'd trust that `cargo check` and friends are sufficient
+# for building, but due to the complicated nature of the build.rs
+# statically linking in a C lib, we want to ensure that two scenarios work:
+#
+#   1. Naive `cargo build` with go on path.
+#   2. `nix build` which is strict about inputs and outputs.
+#
+# If both of those setups work, then we've defined the build adequatedly.
+
+name: build
+on:
+  pull_request:
+jobs:
+  cargo:
+    name: cargo build
+    runs-on: buildjet-8vcpu-ubuntu-2204
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: install nix
+        uses: nixbuild/nix-quick-install-action@v28
+
+      - name: setup nix cache
+        uses: nix-community/cache-nix-action@v5
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          backend: buildjet
+
+      - name: Load rust cache
+        uses: astriaorg/buildjet-rust-cache@v2.5.1
+
+      - name: run cargo build
+        run: >-
+          nix develop --command
+          cargo build --release
+
+  nix:
+    name: nix build
+    runs-on: buildjet-8vcpu-ubuntu-2204
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: install nix
+        uses: nixbuild/nix-quick-install-action@v28
+
+      - name: setup nix cache
+        uses: nix-community/cache-nix-action@v5
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          backend: buildjet
+
+      - name: load rust cache
+        uses: astriaorg/buildjet-rust-cache@v2.5.1
+
+      - name: run nix build
+        run: nix build

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 # Ignore .envrc; copy from .envrc.example to get started
 .envrc
 .direnv/
+
+# ignore nix builds
+/result

--- a/build.rs
+++ b/build.rs
@@ -1,24 +1,90 @@
+//! The `penumbra-indexer` binary requires a CometBFT C archive
+//! for linking. That build-time dependency must be built via go.
+//! By default, cargo will try to use `go` on PATH to perform
+//! the build. If you wish to build the C archive yourself,
+//! you can provide a fullpath to it via the env var
+//!
+//!   PENUMBRA_REINDEXER_STATIC_LIB
+//!
+//! Currently the cargo cache is invalidated if this `build.rs` file
+//! changes. Makes sense, maybe that's default.
+
 use std::env;
-use std::path::Path;
+use std::path::PathBuf;
 use std::process::Command;
 
-fn main() {
-    let out_dir = env::var("OUT_DIR").unwrap();
-    let go_dir = Path::new(&env::var("CARGO_MANIFEST_DIR").unwrap()).join("go");
+// Build the C archive for cometbft via golang.
+//
+// Assumes that a sufficient golang development environment exists,
+// including `go` on the PATH. If you wish to prebuild the C archive
+// and pass it into the cargo build, set `PENUMBRA_REINDEXER_STATIC_LIB` instead.
+fn build_cometbft_c_archive() -> PathBuf {
+    // Cargo will automatically set `OUT_DIR` depending on the target and profile.
+    let cargo_out_dir = PathBuf::from(env::var("OUT_DIR").expect("cargo build should set OUT_DIR"));
+
+    // Set the golang source directory to `go` within the crate root.
+    let go_source_dir = PathBuf::from(
+        env::var("CARGO_MANIFEST_DIR").expect("cargo build should set CARGO_MANIFEST_DIR"),
+    )
+    .join("go");
 
     // Build Go static library
+    let archive_filepath = cargo_out_dir.join("libcometbft.a");
     let status = Command::new("go")
-        .args(&["build", "-buildmode=c-archive", "-o"])
-        .arg(&format!("{}/libcometbft.a", out_dir))
+        .args(&[
+            "build",
+            "-buildmode=c-archive",
+            "-o",
+            archive_filepath
+                .as_os_str()
+                .to_str()
+                .expect("failed to convert c-archive filepath to str"),
+        ])
+        .current_dir(&go_source_dir)
         .arg("cometbft.go")
-        .current_dir(&go_dir)
         .status()
         .expect("failed to run go build command; make sure go is installed and on PATH");
-    assert!(status.success());
+    assert!(
+        status.success(),
+        "failed to build c-archive of cometbft code"
+    );
+    archive_filepath
+}
+
+fn main() {
+    // Check if a prebuilt static lib is provided.
+    let static_lib = match env::var("PENUMBRA_REINDEXER_STATIC_LIB") {
+        Ok(p) => {
+            let p = PathBuf::from(&p);
+            // Check that the path actually exists, otherwise build failures will be confusing
+            assert!(
+                p.exists(),
+                "static lib for cometbft not found: {}",
+                &p.display()
+            );
+            p
+        }
+        // Fall back to building the required static lib automatically, via local `go`.
+        Err(_e) => build_cometbft_c_archive(),
+    };
+
+    let static_lib_dir = static_lib
+        .parent()
+        .expect("failed to find parent directory of archive");
 
     // Link the Go static library
-    println!("cargo:rustc-link-search=native={}", out_dir);
+    println!(
+        "cargo:rustc-link-search=native={}",
+        static_lib_dir.display()
+    );
     println!("cargo:rustc-link-lib=static=cometbft");
-    // Rerun the build when the Go changes
+
+    // Rerun the build if the static lib changed, but only if was provided out of band.
+    // Otherwise, we'll bust the build cache based on timestamp of the `go` directory.
+    println!("cargo::rerun-if-env-changed=PENUMBRA_REINDEXER_STATIC_LIB");
+    if let Ok(_) = env::var("PENUMBRA_REINDEXER_STATIC_LIB") {
+        println!("cargo::rerun-if-changed={}", static_lib_dir.display());
+    }
+    // Rerun the build when the Go code changes
     println!("cargo::rerun-if-changed=go");
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,4 +1,13 @@
 {
+  # This Nix flake represents a two-pass build:
+  #
+  #   1. Build a C archive from CometBFT golang code;
+  #   2. Statically link that C archive into Rust binary via build.rs.
+  #
+  # Therefore there are two packages defined to declare the dependency.
+  # The project's `build.rs` is smart enough to build the golang code on the fly,
+  # but nix doesn't permit network access in the buildPhase, so we need to be explicit
+  # about the `libcometbft.a` file being an ouput of one derivation and the input to another.
   description = "A nix development shell and build environment for penumbra-reindexer";
 
   inputs = {
@@ -11,7 +20,6 @@
     };
     crane = {
       url = "github:ipetkov/crane";
-      inputs = { nixpkgs.follows = "nixpkgs"; };
     };
   };
 
@@ -26,12 +34,66 @@
 
           # Set up for Rust builds.
           craneLib = crane.mkLib pkgs;
-
           # Important environment variables so that the build can find the necessary libraries
           LIBCLANG_PATH="${pkgs.libclang.lib}/lib";
           ROCKSDB_LIB_DIR="${pkgs.rocksdb.out}/lib";
+
         in with pkgs; with pkgs.lib; let
-          # All the Penumbra binaries
+          # Build a C-archive via the cometbft golang module,
+          # for linking into the `penumbra-reindexer` binary at build time.
+          cometbftArchive = pkgs.buildGoModule {
+            pname = "libcometbft-archive";
+            # Extract the verison string from the cometbft golang dep, and use that as the version
+            # for the C archive we're building.
+            version = builtins.head (
+              builtins.match ".*github.com/cometbft/cometbft (v[0-9]+\\.[0-9]+\\.[0-9]+).*" (
+                builtins.readFile ./go/go.mod
+              )
+            );
+
+            # The checksum represents all golang dependencies, and will change whenever deps are bumped.
+            # To bump a golang dep:
+            #
+            #   1. edit the `go/go.mod` file with the new versions
+            #   2. run `go mod tidy` within the `go` directory
+            #   3. run `nix build`, view mismatched hash, update `vendorHash` value below.
+            #
+            vendorHash = "sha256-yO7lAZ+aS25a+Nmq09kcJTZcCNDB1Kk1WoFQ20b4Mxk=";
+
+            # Ensure Go doesn't treat the golang source directory as GOPATH;
+            # this is only necessary because we've named the subdir `go`.
+            src = ./go;
+            preBuild = ''
+              export GOPATH="$TMPDIR/go-path"
+              export GOCACHE="$TMPDIR/go-cache"
+              export GO111MODULE=on
+            '';
+
+            # Override the buildPhase to provide instructions for C archive.
+            buildPhase = ''
+              runHook preBuild
+              go build -buildmode=c-archive -o libcometbft.a ./cometbft.go
+              runHook postBuild
+            '';
+
+            # Override the installPhase to copy the built artifacts, and that's all.
+            # Technically we only need it to land in `$lib`, but we'll copy it to `$out/`
+            # as well, so it's easier to debug, or reference directly from a non-nix
+            # `cargo build`.
+            outputs = [ "out" "lib" ];
+            installPhase = ''
+              runHook preInstall
+              mkdir -p $lib/lib $out
+              cp libcometbft.a $lib/lib/
+              cp libcometbft.a $out/
+              runHook postInstall
+            '';
+
+            # Don't run checks; will fail on libs, rather than binaries.
+            doCheck = false;
+
+          };
+          # Build the `penumbra-reindexer` binary
           penumbraReindexer = (craneLib.buildPackage {
             pname = "penumbra-reindexer";
             # what
@@ -51,12 +113,22 @@
                 (craneLib.filterCargoSources path type);
             };
             nativeBuildInputs = [ pkg-config ];
-            buildInputs = if stdenv.hostPlatform.isDarwin then 
-              with pkgs.darwin.apple_sdk.frameworks; [clang openssl rocksdb SystemConfiguration CoreServices go]
-            else
-              [clang openssl rocksdb go];
+            buildInputs = [
+              clang openssl rocksdb go cometbftArchive
+              ] ++ lib.optionals pkgs.stdenv.isDarwin [
+                # mac-only deps
+                pkgs.darwin.apple_sdk.frameworks.SystemConfiguration
+                pkgs.darwin.apple_sdk.frameworks.CoreServices
+            ];
 
             inherit system LIBCLANG_PATH ROCKSDB_LIB_DIR;
+
+            # Declare the custom-built C archive via env var, so `build.rs` picks it up.
+            # The library path is accessible to the rust build due to `cometbftArchive`
+            # being included as a `buildInput`.
+            preBuild = ''
+              export PENUMBRA_REINDEXER_STATIC_LIB="${cometbftArchive.lib}/lib/libcometbft.a";
+            '';
             cargoExtraArgs = "-p penumbra-reindexer";
             meta = {
               description = "A reindexing tool for Penumbra ABCI event data";
@@ -65,15 +137,14 @@
             };
           }).overrideAttrs (_: { doCheck = false; }); # Disable tests to improve build times
 
-        in rec {
-          packages = { inherit penumbraReindexer ; };
+        in {
+          packages = {
+            inherit penumbraReindexer ;
+            default = penumbraReindexer;
+          };
           apps = {
             penumbra-reindexer.type = "app";
             penumbra-reindexer.program = "${penumbraReindexer}/bin/penumbra-reindexer";
-          };
-          defaultPackage = symlinkJoin {
-            name = "penumbra-reindexer";
-            paths = [ penumbraReindexer ];
           };
           devShells.default = craneLib.devShell {
             inherit LIBCLANG_PATH ROCKSDB_LIB_DIR;


### PR DESCRIPTION
The existing `build.rs` script assumes that go has been set up sufficiently, and calls out to it to build the static library for cometbft for linking against. That's rad, but naively calling out to `go build` from inside `nix build` fails, because the rust overlay doesn't know anything about golang, and forbids arbitrary network calls.

Instead, we'll have to be explicit about preparing the `libcomebft.a` static lib as a discrete output, and consuming it as an input in the rust build. We can do so by opting in to using a prebuilt lib via env var in the `build.rs` script.

This change improves the nix config, making it sufficiently defined to perform a `nix build` successfully. Careful attention was given to preserving the existing functionality so that `cargo build` will still do the right thing, as long as golang is available.