### PR TITLE
feat: add support for penumbra v0.81.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,6 +925,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "cnidarium"
+version = "0.81.3"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.81.3#8521a130b43aca39892a5ba27eb95eddc9a263ed"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "base64 0.21.7",
+ "borsh",
+ "futures",
+ "hex",
+ "ibc-proto",
+ "ibc-types",
+ "ics23",
+ "jmt",
+ "metrics",
+ "once_cell",
+ "parking_lot",
+ "pbjson",
+ "pin-project",
+ "prost",
+ "regex",
+ "rocksdb",
+ "serde",
+ "sha2 0.10.8",
+ "smallvec",
+ "tempfile",
+ "tendermint",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tracing",
+]
+
+[[package]]
 name = "cnidarium-component"
 version = "0.79.5"
 source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.5#46efbca736ea95d86d40a28b2f77005047ba4c57"
@@ -944,6 +978,18 @@ dependencies = [
  "anyhow",
  "async-trait",
  "cnidarium 0.80.11",
+ "hex",
+ "tendermint",
+]
+
+[[package]]
+name = "cnidarium-component"
+version = "0.81.3"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.81.3#8521a130b43aca39892a5ba27eb95eddc9a263ed"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "cnidarium 0.81.3",
  "hex",
  "tendermint",
 ]
@@ -1200,6 +1246,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "decaf377-fmd"
+version = "0.81.3"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.81.3#8521a130b43aca39892a5ba27eb95eddc9a263ed"
+dependencies = [
+ "ark-ff",
+ "ark-serialize",
+ "bitvec",
+ "blake2b_simd 1.0.2",
+ "decaf377",
+ "rand_core",
+ "thiserror",
+]
+
+[[package]]
 name = "decaf377-ka"
 version = "0.79.5"
 source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.5#46efbca736ea95d86d40a28b2f77005047ba4c57"
@@ -1217,6 +1277,20 @@ dependencies = [
 name = "decaf377-ka"
 version = "0.80.11"
 source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.80.11#0d0b319104ae6bfa75dbd1eb31287c979462ee7d"
+dependencies = [
+ "ark-ff",
+ "decaf377",
+ "hex",
+ "rand_core",
+ "thiserror",
+ "zeroize",
+ "zeroize_derive",
+]
+
+[[package]]
+name = "decaf377-ka"
+version = "0.81.3"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.81.3#8521a130b43aca39892a5ba27eb95eddc9a263ed"
 dependencies = [
  "ark-ff",
  "decaf377",
@@ -3242,6 +3316,81 @@ dependencies = [
 ]
 
 [[package]]
+name = "penumbra-app"
+version = "0.81.3"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.81.3#8521a130b43aca39892a5ba27eb95eddc9a263ed"
+dependencies = [
+ "anyhow",
+ "ark-ff",
+ "async-trait",
+ "base64 0.21.7",
+ "bech32",
+ "bincode",
+ "bitvec",
+ "blake2b_simd 1.0.2",
+ "cfg-if",
+ "cnidarium 0.81.3",
+ "cnidarium-component 0.81.3",
+ "decaf377",
+ "decaf377-rdsa",
+ "futures",
+ "hex",
+ "ibc-proto",
+ "ibc-types",
+ "ics23",
+ "im",
+ "jmt",
+ "metrics",
+ "once_cell",
+ "parking_lot",
+ "penumbra-asset 0.81.3",
+ "penumbra-auction 0.81.3",
+ "penumbra-community-pool 0.81.3",
+ "penumbra-compact-block 0.81.3",
+ "penumbra-dex 0.81.3",
+ "penumbra-distributions 0.81.3",
+ "penumbra-fee 0.81.3",
+ "penumbra-funding 0.81.3",
+ "penumbra-governance 0.81.3",
+ "penumbra-ibc 0.81.3",
+ "penumbra-keys 0.81.3",
+ "penumbra-num 0.81.3",
+ "penumbra-proof-params 0.81.3",
+ "penumbra-proto 0.81.3",
+ "penumbra-sct 0.81.3",
+ "penumbra-shielded-pool 0.81.3",
+ "penumbra-stake 0.81.3",
+ "penumbra-tct 0.81.3",
+ "penumbra-test-subscriber 0.81.3",
+ "penumbra-tower-trace 0.81.3",
+ "penumbra-transaction 0.81.3",
+ "penumbra-txhash 0.81.3",
+ "prost",
+ "rand_chacha",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_unit_struct",
+ "serde_with",
+ "sha2 0.10.8",
+ "tempfile",
+ "tendermint",
+ "tendermint-light-client-verifier",
+ "tendermint-proto",
+ "tokio",
+ "tokio-util 0.7.11",
+ "tonic",
+ "tonic-reflection",
+ "tonic-web",
+ "tower",
+ "tower-abci",
+ "tower-actor",
+ "tower-service",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "penumbra-asset"
 version = "0.79.5"
 source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.5#46efbca736ea95d86d40a28b2f77005047ba4c57"
@@ -3319,6 +3468,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "penumbra-asset"
+version = "0.81.3"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.81.3#8521a130b43aca39892a5ba27eb95eddc9a263ed"
+dependencies = [
+ "anyhow",
+ "ark-ff",
+ "ark-r1cs-std",
+ "ark-relations",
+ "ark-serialize",
+ "ark-std",
+ "base64 0.21.7",
+ "bech32",
+ "blake2b_simd 1.0.2",
+ "bytes",
+ "decaf377",
+ "decaf377-fmd 0.81.3",
+ "decaf377-rdsa",
+ "derivative",
+ "ethnum",
+ "getrandom",
+ "hex",
+ "ibig",
+ "num-bigint",
+ "once_cell",
+ "pbjson-types",
+ "penumbra-num 0.81.3",
+ "penumbra-proto 0.81.3",
+ "poseidon377",
+ "rand",
+ "rand_core",
+ "regex",
+ "serde",
+ "serde_with",
+ "sha2 0.10.8",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
 name = "penumbra-auction"
 version = "0.79.5"
 source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.5#46efbca736ea95d86d40a28b2f77005047ba4c57"
@@ -3423,6 +3611,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "penumbra-auction"
+version = "0.81.3"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.81.3#8521a130b43aca39892a5ba27eb95eddc9a263ed"
+dependencies = [
+ "anyhow",
+ "ark-ff",
+ "ark-groth16",
+ "ark-r1cs-std",
+ "ark-relations",
+ "ark-serialize",
+ "ark-snark",
+ "async-stream",
+ "async-trait",
+ "base64 0.21.7",
+ "bech32",
+ "bitvec",
+ "blake2b_simd 1.0.2",
+ "cnidarium 0.81.3",
+ "cnidarium-component 0.81.3",
+ "decaf377",
+ "decaf377-rdsa",
+ "futures",
+ "hex",
+ "metrics",
+ "once_cell",
+ "pbjson-types",
+ "penumbra-asset 0.81.3",
+ "penumbra-dex 0.81.3",
+ "penumbra-keys 0.81.3",
+ "penumbra-num 0.81.3",
+ "penumbra-proof-params 0.81.3",
+ "penumbra-proto 0.81.3",
+ "penumbra-sct 0.81.3",
+ "penumbra-shielded-pool 0.81.3",
+ "penumbra-tct 0.81.3",
+ "penumbra-txhash 0.81.3",
+ "prost",
+ "prost-types",
+ "rand_chacha",
+ "rand_core",
+ "regex",
+ "serde",
+ "serde_with",
+ "sha2 0.10.8",
+ "tap",
+ "tendermint",
+ "tokio",
+ "tonic",
+ "tracing",
+]
+
+[[package]]
 name = "penumbra-community-pool"
 version = "0.79.5"
 source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.5#46efbca736ea95d86d40a28b2f77005047ba4c57"
@@ -3478,6 +3718,38 @@ dependencies = [
  "penumbra-sct 0.80.11",
  "penumbra-shielded-pool 0.80.11",
  "penumbra-txhash 0.80.11",
+ "prost",
+ "serde",
+ "sha2 0.10.8",
+ "tendermint",
+ "tendermint-light-client-verifier",
+ "tracing",
+]
+
+[[package]]
+name = "penumbra-community-pool"
+version = "0.81.3"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.81.3#8521a130b43aca39892a5ba27eb95eddc9a263ed"
+dependencies = [
+ "anyhow",
+ "ark-ff",
+ "async-trait",
+ "base64 0.21.7",
+ "blake2b_simd 1.0.2",
+ "cnidarium 0.81.3",
+ "cnidarium-component 0.81.3",
+ "futures",
+ "hex",
+ "metrics",
+ "once_cell",
+ "pbjson-types",
+ "penumbra-asset 0.81.3",
+ "penumbra-keys 0.81.3",
+ "penumbra-num 0.81.3",
+ "penumbra-proto 0.81.3",
+ "penumbra-sct 0.81.3",
+ "penumbra-shielded-pool 0.81.3",
+ "penumbra-txhash 0.81.3",
  "prost",
  "serde",
  "sha2 0.10.8",
@@ -3548,6 +3820,42 @@ dependencies = [
  "penumbra-shielded-pool 0.80.11",
  "penumbra-stake 0.80.11",
  "penumbra-tct 0.80.11",
+ "rand",
+ "rand_core",
+ "serde",
+ "tendermint",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tracing",
+]
+
+[[package]]
+name = "penumbra-compact-block"
+version = "0.81.3"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.81.3#8521a130b43aca39892a5ba27eb95eddc9a263ed"
+dependencies = [
+ "anyhow",
+ "ark-ff",
+ "async-trait",
+ "blake2b_simd 1.0.2",
+ "bytes",
+ "cnidarium 0.81.3",
+ "cnidarium-component 0.81.3",
+ "decaf377-rdsa",
+ "futures",
+ "im",
+ "metrics",
+ "penumbra-dex 0.81.3",
+ "penumbra-fee 0.81.3",
+ "penumbra-governance 0.81.3",
+ "penumbra-ibc 0.81.3",
+ "penumbra-proof-params 0.81.3",
+ "penumbra-proto 0.81.3",
+ "penumbra-sct 0.81.3",
+ "penumbra-shielded-pool 0.81.3",
+ "penumbra-stake 0.81.3",
+ "penumbra-tct 0.81.3",
  "rand",
  "rand_core",
  "serde",
@@ -3675,6 +3983,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "penumbra-dex"
+version = "0.81.3"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.81.3#8521a130b43aca39892a5ba27eb95eddc9a263ed"
+dependencies = [
+ "anyhow",
+ "ark-ff",
+ "ark-groth16",
+ "ark-r1cs-std",
+ "ark-relations",
+ "ark-serialize",
+ "ark-snark",
+ "async-stream",
+ "async-trait",
+ "base64 0.21.7",
+ "bincode",
+ "blake2b_simd 1.0.2",
+ "cnidarium 0.81.3",
+ "cnidarium-component 0.81.3",
+ "decaf377",
+ "decaf377-fmd 0.81.3",
+ "decaf377-ka 0.81.3",
+ "decaf377-rdsa",
+ "futures",
+ "hex",
+ "im",
+ "metrics",
+ "metrics-exporter-prometheus",
+ "once_cell",
+ "parking_lot",
+ "pbjson-types",
+ "penumbra-asset 0.81.3",
+ "penumbra-fee 0.81.3",
+ "penumbra-keys 0.81.3",
+ "penumbra-num 0.81.3",
+ "penumbra-proof-params 0.81.3",
+ "penumbra-proto 0.81.3",
+ "penumbra-sct 0.81.3",
+ "penumbra-shielded-pool 0.81.3",
+ "penumbra-tct 0.81.3",
+ "penumbra-txhash 0.81.3",
+ "poseidon377",
+ "prost",
+ "rand_core",
+ "regex",
+ "serde",
+ "serde_json",
+ "sha2 0.10.8",
+ "tap",
+ "tendermint",
+ "tendermint-light-client-verifier",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tracing",
+]
+
+[[package]]
 name = "penumbra-distributions"
 version = "0.79.5"
 source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.5#46efbca736ea95d86d40a28b2f77005047ba4c57"
@@ -3705,6 +4071,24 @@ dependencies = [
  "penumbra-num 0.80.11",
  "penumbra-proto 0.80.11",
  "penumbra-sct 0.80.11",
+ "serde",
+ "tendermint",
+ "tracing",
+]
+
+[[package]]
+name = "penumbra-distributions"
+version = "0.81.3"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.81.3#8521a130b43aca39892a5ba27eb95eddc9a263ed"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "cnidarium 0.81.3",
+ "cnidarium-component 0.81.3",
+ "penumbra-asset 0.81.3",
+ "penumbra-num 0.81.3",
+ "penumbra-proto 0.81.3",
+ "penumbra-sct 0.81.3",
  "serde",
  "tendermint",
  "tracing",
@@ -3756,6 +4140,33 @@ dependencies = [
  "penumbra-asset 0.80.11",
  "penumbra-num 0.80.11",
  "penumbra-proto 0.80.11",
+ "rand",
+ "rand_core",
+ "serde",
+ "tendermint",
+ "tonic",
+ "tracing",
+]
+
+[[package]]
+name = "penumbra-fee"
+version = "0.81.3"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.81.3#8521a130b43aca39892a5ba27eb95eddc9a263ed"
+dependencies = [
+ "anyhow",
+ "ark-ff",
+ "async-trait",
+ "blake2b_simd 1.0.2",
+ "bytes",
+ "cnidarium 0.81.3",
+ "cnidarium-component 0.81.3",
+ "decaf377",
+ "decaf377-rdsa",
+ "im",
+ "metrics",
+ "penumbra-asset 0.81.3",
+ "penumbra-num 0.81.3",
+ "penumbra-proto 0.81.3",
  "rand",
  "rand_core",
  "serde",
@@ -3807,6 +4218,30 @@ dependencies = [
  "penumbra-sct 0.80.11",
  "penumbra-shielded-pool 0.80.11",
  "penumbra-stake 0.80.11",
+ "serde",
+ "tendermint",
+ "tracing",
+]
+
+[[package]]
+name = "penumbra-funding"
+version = "0.81.3"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.81.3#8521a130b43aca39892a5ba27eb95eddc9a263ed"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "cnidarium 0.81.3",
+ "cnidarium-component 0.81.3",
+ "futures",
+ "metrics",
+ "penumbra-asset 0.81.3",
+ "penumbra-community-pool 0.81.3",
+ "penumbra-distributions 0.81.3",
+ "penumbra-num 0.81.3",
+ "penumbra-proto 0.81.3",
+ "penumbra-sct 0.81.3",
+ "penumbra-shielded-pool 0.81.3",
+ "penumbra-stake 0.81.3",
  "serde",
  "tendermint",
  "tracing",
@@ -3919,6 +4354,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "penumbra-governance"
+version = "0.81.3"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.81.3#8521a130b43aca39892a5ba27eb95eddc9a263ed"
+dependencies = [
+ "anyhow",
+ "ark-ff",
+ "ark-groth16",
+ "ark-r1cs-std",
+ "ark-relations",
+ "ark-serialize",
+ "ark-snark",
+ "async-stream",
+ "async-trait",
+ "base64 0.21.7",
+ "blake2b_simd 1.0.2",
+ "bytes",
+ "cnidarium 0.81.3",
+ "cnidarium-component 0.81.3",
+ "decaf377",
+ "decaf377-rdsa",
+ "futures",
+ "ibc-types",
+ "im",
+ "metrics",
+ "once_cell",
+ "pbjson-types",
+ "penumbra-asset 0.81.3",
+ "penumbra-distributions 0.81.3",
+ "penumbra-ibc 0.81.3",
+ "penumbra-keys 0.81.3",
+ "penumbra-num 0.81.3",
+ "penumbra-proof-params 0.81.3",
+ "penumbra-proto 0.81.3",
+ "penumbra-sct 0.81.3",
+ "penumbra-shielded-pool 0.81.3",
+ "penumbra-stake 0.81.3",
+ "penumbra-tct 0.81.3",
+ "penumbra-txhash 0.81.3",
+ "rand",
+ "rand_chacha",
+ "rand_core",
+ "regex",
+ "serde",
+ "serde_json",
+ "tap",
+ "tendermint",
+ "thiserror",
+ "tokio",
+ "tonic",
+ "tracing",
+]
+
+[[package]]
 name = "penumbra-ibc"
 version = "0.79.5"
 source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.5#46efbca736ea95d86d40a28b2f77005047ba4c57"
@@ -3980,6 +4468,43 @@ dependencies = [
  "penumbra-proto 0.80.11",
  "penumbra-sct 0.80.11",
  "penumbra-txhash 0.80.11",
+ "prost",
+ "serde",
+ "serde_json",
+ "sha2 0.10.8",
+ "tendermint",
+ "tendermint-light-client-verifier",
+ "time",
+ "tonic",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "penumbra-ibc"
+version = "0.81.3"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.81.3#8521a130b43aca39892a5ba27eb95eddc9a263ed"
+dependencies = [
+ "anyhow",
+ "ark-ff",
+ "async-trait",
+ "base64 0.21.7",
+ "blake2b_simd 1.0.2",
+ "cnidarium 0.81.3",
+ "futures",
+ "hex",
+ "ibc-proto",
+ "ibc-types",
+ "ics23",
+ "metrics",
+ "num-traits",
+ "once_cell",
+ "pbjson-types",
+ "penumbra-asset 0.81.3",
+ "penumbra-num 0.81.3",
+ "penumbra-proto 0.81.3",
+ "penumbra-sct 0.81.3",
+ "penumbra-txhash 0.81.3",
  "prost",
  "serde",
  "serde_json",
@@ -4081,6 +4606,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "penumbra-keys"
+version = "0.81.3"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.81.3#8521a130b43aca39892a5ba27eb95eddc9a263ed"
+dependencies = [
+ "aes",
+ "anyhow",
+ "ark-ff",
+ "ark-r1cs-std",
+ "ark-relations",
+ "ark-serialize",
+ "ark-std",
+ "base64 0.21.7",
+ "bech32",
+ "bip32",
+ "blake2b_simd 1.0.2",
+ "bytes",
+ "chacha20poly1305",
+ "decaf377",
+ "decaf377-fmd 0.81.3",
+ "decaf377-ka 0.81.3",
+ "decaf377-rdsa",
+ "derivative",
+ "ethnum",
+ "f4jumble 0.1.1",
+ "hex",
+ "hmac",
+ "ibig",
+ "num-bigint",
+ "once_cell",
+ "pbkdf2",
+ "penumbra-asset 0.81.3",
+ "penumbra-proto 0.81.3",
+ "penumbra-tct 0.81.3",
+ "poseidon377",
+ "rand",
+ "rand_core",
+ "regex",
+ "serde",
+ "sha2 0.10.8",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
 name = "penumbra-num"
 version = "0.79.5"
 source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.5#46efbca736ea95d86d40a28b2f77005047ba4c57"
@@ -4153,6 +4722,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "penumbra-num"
+version = "0.81.3"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.81.3#8521a130b43aca39892a5ba27eb95eddc9a263ed"
+dependencies = [
+ "anyhow",
+ "ark-ff",
+ "ark-groth16",
+ "ark-r1cs-std",
+ "ark-relations",
+ "ark-serialize",
+ "ark-snark",
+ "ark-std",
+ "base64 0.21.7",
+ "bech32",
+ "blake2b_simd 1.0.2",
+ "bytes",
+ "decaf377",
+ "decaf377-fmd 0.81.3",
+ "decaf377-rdsa",
+ "derivative",
+ "ethnum",
+ "hex",
+ "ibig",
+ "num-bigint",
+ "once_cell",
+ "penumbra-proto 0.81.3",
+ "rand",
+ "rand_core",
+ "regex",
+ "serde",
+ "sha2 0.10.8",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
 name = "penumbra-proof-params"
 version = "0.79.5"
 source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.5#46efbca736ea95d86d40a28b2f77005047ba4c57"
@@ -4182,6 +4787,31 @@ dependencies = [
 name = "penumbra-proof-params"
 version = "0.80.11"
 source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.80.11#0d0b319104ae6bfa75dbd1eb31287c979462ee7d"
+dependencies = [
+ "anyhow",
+ "ark-ec",
+ "ark-ff",
+ "ark-groth16",
+ "ark-r1cs-std",
+ "ark-relations",
+ "ark-serialize",
+ "ark-snark",
+ "ark-std",
+ "bech32",
+ "decaf377",
+ "num-bigint",
+ "once_cell",
+ "rand",
+ "rand_core",
+ "serde",
+ "sha2 0.10.8",
+ "tracing",
+]
+
+[[package]]
+name = "penumbra-proof-params"
+version = "0.81.3"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.81.3#8521a130b43aca39892a5ba27eb95eddc9a263ed"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -4298,26 +4928,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "penumbra-proto"
+version = "0.81.3"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.81.3#8521a130b43aca39892a5ba27eb95eddc9a263ed"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bech32",
+ "bytes",
+ "cnidarium 0.81.3",
+ "decaf377-fmd 0.81.3",
+ "decaf377-rdsa",
+ "futures",
+ "hex",
+ "ibc-proto",
+ "ibc-types",
+ "ics23",
+ "pbjson",
+ "pbjson-types",
+ "pin-project",
+ "prost",
+ "serde",
+ "serde_json",
+ "subtle-encoding",
+ "tendermint",
+ "tonic",
+ "tracing",
+]
+
+[[package]]
 name = "penumbra-reindexer"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "async-trait",
  "clap",
  "cnidarium 0.79.5",
  "cnidarium 0.80.11",
+ "cnidarium 0.81.3",
  "digest 0.10.7",
  "directories",
  "hex",
  "ibc-types",
  "penumbra-app 0.79.5",
  "penumbra-app 0.80.11",
+ "penumbra-app 0.81.3",
  "penumbra-governance 0.80.11",
+ "penumbra-governance 0.81.3",
  "penumbra-ibc 0.79.5",
  "penumbra-ibc 0.80.11",
+ "penumbra-ibc 0.81.3",
  "penumbra-proto 0.80.6",
  "penumbra-sct 0.80.11",
+ "penumbra-sct 0.81.3",
  "penumbra-transaction 0.80.11",
+ "penumbra-transaction 0.81.3",
  "prost",
  "serde_json",
  "sha2 0.10.8",
@@ -4393,6 +5058,42 @@ dependencies = [
  "penumbra-keys 0.80.11",
  "penumbra-proto 0.80.11",
  "penumbra-tct 0.80.11",
+ "poseidon377",
+ "rand",
+ "rand_core",
+ "serde",
+ "tendermint",
+ "tonic",
+ "tracing",
+]
+
+[[package]]
+name = "penumbra-sct"
+version = "0.81.3"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.81.3#8521a130b43aca39892a5ba27eb95eddc9a263ed"
+dependencies = [
+ "anyhow",
+ "ark-ff",
+ "ark-r1cs-std",
+ "ark-relations",
+ "ark-serialize",
+ "async-trait",
+ "bincode",
+ "blake2b_simd 1.0.2",
+ "bytes",
+ "chrono",
+ "cnidarium 0.81.3",
+ "cnidarium-component 0.81.3",
+ "decaf377",
+ "decaf377-rdsa",
+ "hex",
+ "im",
+ "metrics",
+ "once_cell",
+ "pbjson-types",
+ "penumbra-keys 0.81.3",
+ "penumbra-proto 0.81.3",
+ "penumbra-tct 0.81.3",
  "poseidon377",
  "rand",
  "rand_core",
@@ -4511,6 +5212,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "penumbra-shielded-pool"
+version = "0.81.3"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.81.3#8521a130b43aca39892a5ba27eb95eddc9a263ed"
+dependencies = [
+ "anyhow",
+ "ark-ff",
+ "ark-groth16",
+ "ark-r1cs-std",
+ "ark-relations",
+ "ark-serialize",
+ "ark-snark",
+ "async-stream",
+ "async-trait",
+ "base64 0.21.7",
+ "blake2b_simd 1.0.2",
+ "bytes",
+ "chacha20poly1305",
+ "cnidarium 0.81.3",
+ "cnidarium-component 0.81.3",
+ "decaf377",
+ "decaf377-fmd 0.81.3",
+ "decaf377-ka 0.81.3",
+ "decaf377-rdsa",
+ "futures",
+ "hex",
+ "ibc-proto",
+ "ibc-types",
+ "im",
+ "metrics",
+ "once_cell",
+ "penumbra-asset 0.81.3",
+ "penumbra-ibc 0.81.3",
+ "penumbra-keys 0.81.3",
+ "penumbra-num 0.81.3",
+ "penumbra-proof-params 0.81.3",
+ "penumbra-proto 0.81.3",
+ "penumbra-sct 0.81.3",
+ "penumbra-tct 0.81.3",
+ "penumbra-txhash 0.81.3",
+ "poseidon377",
+ "prost",
+ "rand",
+ "rand_core",
+ "regex",
+ "serde",
+ "serde_json",
+ "tap",
+ "tendermint",
+ "thiserror",
+ "tonic",
+ "tracing",
+]
+
+[[package]]
 name = "penumbra-stake"
 version = "0.79.5"
 source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.5#46efbca736ea95d86d40a28b2f77005047ba4c57"
@@ -4611,6 +5366,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "penumbra-stake"
+version = "0.81.3"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.81.3#8521a130b43aca39892a5ba27eb95eddc9a263ed"
+dependencies = [
+ "anyhow",
+ "ark-ff",
+ "ark-groth16",
+ "ark-r1cs-std",
+ "ark-relations",
+ "ark-serialize",
+ "ark-snark",
+ "async-stream",
+ "async-trait",
+ "base64 0.21.7",
+ "bech32",
+ "bitvec",
+ "cnidarium 0.81.3",
+ "cnidarium-component 0.81.3",
+ "decaf377",
+ "decaf377-rdsa",
+ "futures",
+ "hex",
+ "im",
+ "metrics",
+ "once_cell",
+ "penumbra-asset 0.81.3",
+ "penumbra-distributions 0.81.3",
+ "penumbra-keys 0.81.3",
+ "penumbra-num 0.81.3",
+ "penumbra-proof-params 0.81.3",
+ "penumbra-proto 0.81.3",
+ "penumbra-sct 0.81.3",
+ "penumbra-shielded-pool 0.81.3",
+ "penumbra-tct 0.81.3",
+ "penumbra-txhash 0.81.3",
+ "rand_chacha",
+ "rand_core",
+ "regex",
+ "serde",
+ "serde_unit_struct",
+ "serde_with",
+ "sha2 0.10.8",
+ "tap",
+ "tendermint",
+ "tokio",
+ "tonic",
+ "tracing",
+]
+
+[[package]]
 name = "penumbra-tct"
 version = "0.79.5"
 source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.5#46efbca736ea95d86d40a28b2f77005047ba4c57"
@@ -4660,6 +5465,35 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "penumbra-proto 0.80.11",
+ "poseidon377",
+ "rand",
+ "serde",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "penumbra-tct"
+version = "0.81.3"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.81.3#8521a130b43aca39892a5ba27eb95eddc9a263ed"
+dependencies = [
+ "ark-ed-on-bls12-377",
+ "ark-ff",
+ "ark-r1cs-std",
+ "ark-relations",
+ "ark-serialize",
+ "async-trait",
+ "blake2b_simd 1.0.2",
+ "decaf377",
+ "derivative",
+ "futures",
+ "getrandom",
+ "hash_hasher",
+ "hex",
+ "im",
+ "once_cell",
+ "parking_lot",
+ "penumbra-proto 0.81.3",
  "poseidon377",
  "rand",
  "serde",
@@ -4719,6 +5553,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "penumbra-test-subscriber"
+version = "0.81.3"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.81.3#8521a130b43aca39892a5ba27eb95eddc9a263ed"
+dependencies = [
+ "tracing",
+ "tracing-subscriber 0.3.18",
+]
+
+[[package]]
 name = "penumbra-tower-trace"
 version = "0.79.5"
 source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.5#46efbca736ea95d86d40a28b2f77005047ba4c57"
@@ -4744,6 +5587,28 @@ dependencies = [
 name = "penumbra-tower-trace"
 version = "0.80.11"
 source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.80.11#0d0b319104ae6bfa75dbd1eb31287c979462ee7d"
+dependencies = [
+ "futures",
+ "hex",
+ "http",
+ "pin-project",
+ "pin-project-lite",
+ "sha2 0.10.8",
+ "tendermint",
+ "tendermint-proto",
+ "tokio",
+ "tokio-stream",
+ "tokio-util 0.7.11",
+ "tonic",
+ "tower",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "penumbra-tower-trace"
+version = "0.81.3"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.81.3#8521a130b43aca39892a5ba27eb95eddc9a263ed"
 dependencies = [
  "futures",
  "hex",
@@ -4867,6 +5732,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "penumbra-transaction"
+version = "0.81.3"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.81.3#8521a130b43aca39892a5ba27eb95eddc9a263ed"
+dependencies = [
+ "anyhow",
+ "ark-ff",
+ "ark-serialize",
+ "base64 0.21.7",
+ "bech32",
+ "blake2b_simd 1.0.2",
+ "bytes",
+ "chacha20poly1305",
+ "decaf377",
+ "decaf377-fmd 0.81.3",
+ "decaf377-ka 0.81.3",
+ "decaf377-rdsa",
+ "derivative",
+ "hex",
+ "ibc-proto",
+ "ibc-types",
+ "num-bigint",
+ "once_cell",
+ "pbjson-types",
+ "penumbra-asset 0.81.3",
+ "penumbra-auction 0.81.3",
+ "penumbra-community-pool 0.81.3",
+ "penumbra-dex 0.81.3",
+ "penumbra-fee 0.81.3",
+ "penumbra-governance 0.81.3",
+ "penumbra-ibc 0.81.3",
+ "penumbra-keys 0.81.3",
+ "penumbra-num 0.81.3",
+ "penumbra-proof-params 0.81.3",
+ "penumbra-proto 0.81.3",
+ "penumbra-sct 0.81.3",
+ "penumbra-shielded-pool 0.81.3",
+ "penumbra-stake 0.81.3",
+ "penumbra-tct 0.81.3",
+ "penumbra-txhash 0.81.3",
+ "poseidon377",
+ "rand",
+ "rand_core",
+ "regex",
+ "serde",
+ "serde_json",
+ "sha2 0.10.8",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "penumbra-txhash"
 version = "0.79.5"
 source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.5#46efbca736ea95d86d40a28b2f77005047ba4c57"
@@ -4891,6 +5808,20 @@ dependencies = [
  "hex",
  "penumbra-proto 0.80.11",
  "penumbra-tct 0.80.11",
+ "serde",
+]
+
+[[package]]
+name = "penumbra-txhash"
+version = "0.81.3"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.81.3#8521a130b43aca39892a5ba27eb95eddc9a263ed"
+dependencies = [
+ "anyhow",
+ "blake2b_simd 1.0.2",
+ "getrandom",
+ "hex",
+ "penumbra-proto 0.81.3",
+ "penumbra-tct 0.81.3",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["Penumbra Labs <team@penumbralabs.xyz"]
 description = "A reindexing tool for Penumbra ABCI event data"
 homepage = "https://penumbra.zone"
 repository = "https://github.com/penumbra-zone/reindexer"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 
@@ -36,6 +36,13 @@ penumbra-governance-v0o80 = { package = "penumbra-governance", git = "https://gi
 penumbra-ibc-v0o80 = { package = "penumbra-ibc", git = "https://github.com/penumbra-zone/penumbra", tag = "v0.80.11" }
 penumbra-sct-v0o80 = { package = "penumbra-sct", git = "https://github.com/penumbra-zone/penumbra", tag = "v0.80.11" }
 penumbra-transaction-v0o80 = { package = "penumbra-transaction", git = "https://github.com/penumbra-zone/penumbra", tag = "v0.80.11" }
+# V0.81 dependencies
+cnidarium-v0o81 = { package = "cnidarium", git = "https://github.com/penumbra-zone/penumbra", tag = "v0.81.3" }
+penumbra-app-v0o81 = { package = "penumbra-app", git = "https://github.com/penumbra-zone/penumbra", tag = "v0.81.3" }
+penumbra-governance-v0o81 = { package = "penumbra-governance", git = "https://github.com/penumbra-zone/penumbra", tag = "v0.81.3" }
+penumbra-ibc-v0o81 = { package = "penumbra-ibc", git = "https://github.com/penumbra-zone/penumbra", tag = "v0.81.3" }
+penumbra-sct-v0o81 = { package = "penumbra-sct", git = "https://github.com/penumbra-zone/penumbra", tag = "v0.81.3" }
+penumbra-transaction-v0o81 = { package = "penumbra-transaction", git = "https://github.com/penumbra-zone/penumbra", tag = "v0.81.3" }
 sha2 = { version = "0.10.8", default-features = false }
 digest = { version = "0.10.7", default-features = false }
 prost = "0.12.6"

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ and you want to store the state in `/tmp/regen`, you'd do:
 
 ```bash
 penumbra-reindexer regen --database-url postgresql://localhost:5432/penumbra_raw?sslmode=disable --working-dir /tmp/regen --stop-height 501974
+penumbra-reindexer regen --database-url postgresql://localhost:5432/penumbra_raw?sslmode=disable --working-dir /tmp/regen --stop-height 2611799
 penumbra-reindexer regen --database-url postgresql://localhost:5432/penumbra_raw?sslmode=disable --working-dir /tmp/regen
 ```
 

--- a/src/penumbra.rs
+++ b/src/penumbra.rs
@@ -53,13 +53,18 @@ enum Version {
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 enum RegenerationStep {
-    Migrate {
-        from: Version,
-        to: Version,
-    },
+    /// Represents a migration, as would be performed by `pd migrate`,
+    /// so munge node state on a planned upgrade boundary.
+    Migrate { from: Version, to: Version },
     InitThenRunTo {
+        /// The `genesis_height` is the block at which the chain will resume, post-upgrade.
+        /// For reference, this is the same block specified in an `upgrade-plan` proposal,
+        /// as the `upgradePlan.height` field.
         genesis_height: u64,
         version: Version,
+        /// The `last_block` is the block immediately preceding a planned chain upgrade.
+        /// For reference, this is the block specified in an `upgrade-plan` proposal,
+        /// minus 1. For chains with no known upgrade, this should be `None`.
         last_block: Option<u64>,
     },
     RunTo {
@@ -216,21 +221,20 @@ impl RegenerationPlan {
                     InitThenRunTo {
                         genesis_height: 501975,
                         version: V0o80,
-                        last_block: Some(2611800),
+                        last_block: Some(2611799),
                     },
                 ),
-                // new content below here
                 (
-                    2611800,
+                    2611799,
                     Migrate {
                         from: V0o80,
                         to: V0o81,
                     },
                 ),
                 (
-                    2611800,
+                    2611799,
                     InitThenRunTo {
-                        genesis_height: 2611801,
+                        genesis_height: 2611800,
                         version: V0o81,
                         last_block: None,
                     },

--- a/src/penumbra.rs
+++ b/src/penumbra.rs
@@ -152,6 +152,7 @@ impl RegenerationStep {
 ///
 /// This also makes the resulting logic in terms of creating and destroying penumbra applications
 /// easier, because we know the given lifecycle of a version of the penumbra logic.
+#[derive(Debug)]
 struct RegenerationPlan {
     pub steps: Vec<(u64, RegenerationStep)>,
 }
@@ -316,6 +317,12 @@ impl Regenerator {
 
     async fn run_from(mut self, start: Option<u64>, stop: Option<u64>) -> anyhow::Result<()> {
         let plan = RegenerationPlan::penumbra_1().truncate(start, stop);
+        tracing::info!(
+            "plan truncated between {:?}..={:?}: {:?}",
+            start,
+            stop,
+            plan
+        );
         for (start, step) in plan.steps.into_iter() {
             use RegenerationStep::*;
             match step {

--- a/src/penumbra/v0o81.rs
+++ b/src/penumbra/v0o81.rs
@@ -1,0 +1,95 @@
+use std::path::Path;
+
+use async_trait::async_trait;
+use cnidarium_v0o81::Storage;
+use penumbra_app_v0o81::{app::App, PenumbraHost, SUBSTORE_PREFIXES};
+use penumbra_ibc_v0o81::component::HostInterface as _;
+use tendermint::{
+    abci::Event,
+    v0_37::abci::request::{BeginBlock, DeliverTx, EndBlock},
+};
+
+use crate::cometbft::Genesis;
+
+pub struct Penumbra {
+    storage: Storage,
+    app: App,
+}
+
+impl Penumbra {
+    pub async fn load(working_dir: &Path) -> anyhow::Result<Self> {
+        let storage = Storage::load(working_dir.to_owned(), SUBSTORE_PREFIXES.to_vec()).await?;
+        let app = App::new(storage.latest_snapshot());
+        Ok(Self { storage, app })
+    }
+}
+
+#[async_trait]
+impl super::Penumbra for Penumbra {
+    async fn release(self: Box<Self>) {
+        self.storage.release().await
+    }
+
+    async fn genesis(&mut self, genesis: Genesis) -> anyhow::Result<()> {
+        Ok(self
+            .app
+            .init_chain(&serde_json::from_value(genesis.app_state().clone())?)
+            .await)
+    }
+
+    async fn metadata(&self) -> anyhow::Result<(u64, String)> {
+        let snapshot = self.storage.latest_snapshot();
+        let height = PenumbraHost::get_block_height(snapshot.clone()).await?;
+        let chain_id = PenumbraHost::get_chain_id(snapshot).await?;
+        Ok((height, chain_id))
+    }
+
+    async fn begin_block(&mut self, req: &BeginBlock) -> Vec<Event> {
+        self.app.begin_block(&req).await
+    }
+
+    async fn deliver_tx(&mut self, req: &DeliverTx) -> anyhow::Result<Vec<Event>> {
+        self.app.deliver_tx_bytes(&req.tx).await
+    }
+
+    async fn end_block(&mut self, req: &EndBlock) -> Vec<Event> {
+        self.app.end_block(req).await
+    }
+
+    async fn commit(&mut self) -> anyhow::Result<()> {
+        self.app.commit(self.storage.clone()).await;
+        Ok(())
+    }
+}
+
+mod migration {
+    use cnidarium_v0o81::StateDelta;
+    use penumbra_app_v0o80::SUBSTORE_PREFIXES;
+    // use penumbra_app_v0o81::app::StateReadExt as _;
+    use penumbra_governance_v0o81::StateWriteExt;
+    use penumbra_sct_v0o81::component::clock::EpochManager as _;
+    // use penumbra_transaction_v0o81::{Action, Transaction};
+
+    use super::super::Version;
+    use super::*;
+
+    pub async fn migrate(from: Version, working_dir: &Path) -> anyhow::Result<()> {
+        anyhow::ensure!(from == Version::V0o80, "version must be v0.80.x");
+        let storage = Storage::load(working_dir.to_owned(), SUBSTORE_PREFIXES.to_vec()).await?;
+        let initial_state = storage.latest_snapshot();
+        let mut delta = StateDelta::new(initial_state);
+
+        // Reset the application height and halt flag.
+        delta.ready_to_start();
+        delta.put_block_height(0u64);
+
+        // Finally, commit the changes to the chain state.
+        let post_upgrade_root_hash = storage.commit_in_place(delta).await?;
+        tracing::info!(?post_upgrade_root_hash, "post-migration root hash");
+        storage.release().await;
+
+        Ok(())
+    }
+}
+
+pub use migration::migrate;


### PR DESCRIPTION
Adds support for the `v0.80.x` -> `v0.81.x` chain upgrade for the `penumbra-1` chain.

## Testing and review

1. Use a preexisting `reindexer_archive.bin`, or obtain from https://artifacts.plinfra.net/: the one marked `reindexer_archive-height-2609670.sqlite` would be great because it's right before the target upgrade height that we're adding support for.
2. Use an up-to-date node state dir to update the archive: `systemctl stop penumbra cometbft && penumbra-reindexer archive`
3. Ideally, target a fresh database and run `penumbra-reindexer archive [...]` to write to it. That'll take a while, ~20h or so.