### PR TITLE
reindexer: use the pure-go resolver

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -33,6 +33,7 @@ fn build_cometbft_c_archive() -> PathBuf {
     let status = Command::new("go")
         .args(&[
             "build",
+            "-tags=netgo",
             "-buildmode=c-archive",
             "-o",
             archive_filepath


### PR DESCRIPTION
This avoids relying on `libresolv` and fixes #19.