### PR TITLE
chore: bump version to 0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Unreleased
+
+Nothing Yet!
+
+# Version 0.1.3 (2025-01-29)
+
+* feat: add support for `penumbra-testnest-phobos-2` chain
+* feat: add safeguard against plans not matching the archive
+* build: fix builds on macos
+
+# Version 0.1.2 (2025-01-21)
+
+Adds support for the `v0.81.x` protocol changes for the `penumbra-1` chain.
+
+# Version 0.1.1 (2024-12-18)
+
+Bumps the `v0.80.x` deps to `v0.80.11`, to stay in sync with upstream changes.
+
+# Version 0.1.0 (2024-08-25)
+
+Initial release, supporting chain upgrades from `v0.79.x` to `v0.80.x` on the `penumbra-1` chain.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4958,7 +4958,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-reindexer"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["Penumbra Labs <team@penumbralabs.xyz"]
 description = "A reindexing tool for Penumbra ABCI event data"
 homepage = "https://penumbra.zone"
 repository = "https://github.com/penumbra-zone/reindexer"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 


### PR DESCRIPTION
I've been bumping the version routinely to ensure the proper versions are used on the relevant nodes. Also adds a changelog, to keep things organized.