### PR TITLE
Fix parsing bugs in begin block

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ license = "MIT OR Apache-2.0"
 
 [features]
 network-integration = []
+expensive-tests = []
 download-archives = []
 
 [dependencies]

--- a/justfile
+++ b/justfile
@@ -15,3 +15,8 @@ test:
 integration:
   rm -rf test_data/ephemeral-storage/
   cargo nextest run --release --features network-integration --nocapture
+
+# Run expensive tests that require local files as input. Assumes integration tests have been run!
+expensive-tests:
+  REINDEXER_SQLITE_DB_FILEPATH=test_data/ephemeral-storage/network/penumbra-1/node0/reindexer_archive.bin \
+    cargo nextest run --release --nocapture --features expensive-tests --test file

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,8 @@ mod command;
 mod files;
 mod indexer;
 mod penumbra;
-mod storage;
-mod tendermint_compat;
+pub mod storage;
+pub mod tendermint_compat;
 
 /// This is a utility around re-indexing historical Penumbra events.
 #[derive(clap::Parser)]

--- a/src/tendermint_compat.rs
+++ b/src/tendermint_compat.rs
@@ -451,7 +451,7 @@ impl TryInto<tendermint_v0o34::abci::request::BeginBlock> for BeginBlock {
                 // time-in-nanos)?
                 time: tendermint_v0o34::time::Time::from_unix_timestamp(
                     self.0.header.time.unix_timestamp(),
-                    self.0.header.time.unix_timestamp_nanos().try_into()?,
+                    (self.0.header.time.unix_timestamp_nanos() % 1_000_000_000).try_into()?,
                 )?,
                 last_block_id: match self.0.header.last_block_id {
                     Some(last_block_id) => Some(tendermint_v0o34::block::Id {

--- a/src/tendermint_compat.rs
+++ b/src/tendermint_compat.rs
@@ -135,6 +135,7 @@ impl TryFrom<crate::cometbft::Block> for Block {
     }
 }
 
+/*
 impl TryFrom<tendermint_v0o34::Block> for Block {
     type Error = anyhow::Error;
     fn try_from(block: tendermint_v0o34::Block) -> anyhow::Result<Block> {
@@ -311,6 +312,8 @@ impl TryFrom<tendermint_v0o34::Block> for Block {
         Ok(block)
     }
 }
+*/
+
 /// Wrapper type for handling conversions between incompatible versions of Tendermint `BeginBlock`
 /// types. Stores the most recent Tendermint version as a singleton, and defers conversions to
 /// TryInto impls.

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,4 +1,3 @@
-#![cfg(feature = "network-integration")]
 #![allow(dead_code)]
 //! Common utilities for `penumbra-reindexer` integration tests.
 //! Mostly handles downloading files and setting up `pd` node directories,
@@ -196,7 +195,10 @@ pub fn init_tracing() {
     tracing_subscriber::fmt()
         .with_ansi(stderr().is_terminal())
         .with_env_filter(
-            EnvFilter::from_default_env()
+            EnvFilter::try_from_default_env()
+                // Default to "info"-level logging.
+                .or_else(|_| EnvFilter::try_new("info"))
+                .expect("failed to initialize logging")
                 // Without explicitly disabling the `r1cs` target, the ZK proof implementations
                 // will spend an enormous amount of CPU and memory building useless tracing output.
                 .add_directive(

--- a/tests/file.rs
+++ b/tests/file.rs
@@ -1,0 +1,37 @@
+use anyhow::anyhow;
+use penumbra_reindexer::{storage::Storage, tendermint_compat};
+use std::str::FromStr as _;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_begin_block_parsing() -> anyhow::Result<()> {
+    use std::path::PathBuf;
+
+    struct Args {
+        archive_file: PathBuf,
+    }
+
+    impl Args {
+        fn parse() -> anyhow::Result<Self> {
+            let args: Vec<String> = std::env::args().collect();
+            let args_2 = args
+                .get(2)
+                .ok_or(anyhow!("expected archive file name as 3rd argument"))?;
+            let archive_file = PathBuf::from_str(args_2)?;
+            Ok(Self { archive_file })
+        }
+    }
+
+    let args = Args::parse()?;
+    let archive = Storage::new(Some(&args.archive_file), None).await?;
+    let mut height = 1u64;
+    while let Some(block) = archive.get_block(height).await? {
+        let block = tendermint_compat::Block::try_from(block)?;
+        let begin_block = tendermint_compat::BeginBlock::from(block);
+        let _begin_block_v0o34: tendermint_v0o34::abci::request::BeginBlock =
+            begin_block.clone().try_into()?;
+        let _begin_block_v0o40: tendermint_v0o40::abci::request::BeginBlock = begin_block.into();
+        height += 1;
+    }
+
+    Ok(())
+}

--- a/tests/file.rs
+++ b/tests/file.rs
@@ -13,12 +13,16 @@ async fn test_begin_block_parsing() -> anyhow::Result<()> {
 
     impl Args {
         fn parse() -> anyhow::Result<Self> {
-            let args: Vec<String> = std::env::args().collect();
-            let args_2 = args
-                .get(2)
-                .ok_or(anyhow!("expected archive file name as 3rd argument"))?;
-            let archive_file = PathBuf::from_str(args_2)?;
-            Ok(Self { archive_file })
+            // We use an env var rather than a CLI arg so that different invocations of
+            // `cargo test` don't break the ordinal arg parsing.
+            let env_var = "REINDEXER_SQLITE_DB_FILEPATH";
+            match std::env::var(env_var) {
+                Ok(f) => {
+                    let archive_file = PathBuf::from_str(&f)?;
+                    Ok(Self { archive_file })
+                }
+                Err(_) => anyhow::bail!("env var '{}' not set", env_var),
+            }
         }
     }
 

--- a/tests/file.rs
+++ b/tests/file.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "expensive-tests")]
 use anyhow::anyhow;
 use penumbra_reindexer::{storage::Storage, tendermint_compat};
 use std::str::FromStr as _;

--- a/tests/file.rs
+++ b/tests/file.rs
@@ -33,11 +33,18 @@ async fn test_begin_block_parsing() -> anyhow::Result<()> {
         }
     }
 
-    let args = Args::parse()?;
+    let args = match Args::parse() {
+        Ok(x) if std::fs::exists(&x.archive_file)? => x,
+        Ok(_) | Err(_) => {
+            eprintln!("WARNING: failed to parse arguments, or the archive file doesn't exist. Skipping test.");
+            return Ok(());
+        }
+    };
     tracing::info!(
         "running beginblock against local sqlite3 db: {}",
         &args.archive_file.display()
     );
+
     let archive = Storage::new(Some(&args.archive_file), None).await?;
     let mut height = 1u64;
     while let Some(block) = archive.get_block(height).await? {


### PR DESCRIPTION
This fixes a couple issues we missed in the conversion from v040 begin blocks to v034 begin blocks.

This also adds a testing harness which reads all the blocks in an archive, and tests that it's convertible to both types.

This can be run with:

```
cargo test --features expensive-tests --test file '' -- ~/Downloads/reindexer_archive-height-1703224.sqlite
```

replacing the archive file appropriately.

(In the near future I'd like to refactor some of the expensive tests to be under a common feature flag, and take parameters on the command line like this, but that can wait).

Closes #34. (We should check that there aren't other issues, the other types require actually interacting with the simulated penumbra nodes, and I haven't had time to run a reindex yet)