### PR TITLE
fix(tests): fetch matching genesis per phase

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -463,8 +463,8 @@ impl HistoricalArchiveSeries {
             },
 
             HistoricalArchive {
-                download_url: "https://artifacts.plinfra.net/penumbra-1/penumbra-node-archive-height-3349091.tar.gz".try_into()?,
-                checksum_sha256: "32dea0f0bd323f5abdf6453f975418f6c70c6d7da4aa0e06a25911d02cefd842".to_owned(),
+                download_url: "https://artifacts.plinfra.net/penumbra-1/penumbra-node-archive-height-4027443.tar.gz".try_into()?,
+                checksum_sha256: "cfb93391ae348275b221bb1811d59833b4bc2854c92c234fe266506b4a6b7c71".to_owned(),
                 chain_id: chain_id.clone(),
                 dest_dir: dest_dir.clone(),
             },

--- a/tests/penumbra_1.rs
+++ b/tests/penumbra_1.rs
@@ -28,7 +28,7 @@ async fn run_reindexer_archive_step_2() -> anyhow::Result<()> {
 #[tokio::test]
 /// Run `penumbra-reindexer archive` from the second upgrade boundary to the present.
 async fn run_reindexer_archive_step_3() -> anyhow::Result<()> {
-    let expected_blocks = 3349091;
+    let expected_blocks = 4027443;
     run_reindexer_archive_step(PENUMBRA_CHAIN_ID, 2, expected_blocks).await?;
     Ok(())
 }


### PR DESCRIPTION
Each upgrade boundary comes with its own notion of a genesis. For some archives the appropriate genesis file may be bundled in, but other archives only contain `pd/rocksdb/` and `cometbft/data/` dirs. We'll fetch the appropriate genesis file based on the phase during setup of the archive data.

Closes #37.