### PR TITLE
chore: release penumbra-reindexer version 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Nothing Yet!
 
+# Version 0.2.1 (2025-03-18)
+
+* fix: parsing bugs in BeginBlock conversions
+* refactor: remove unused conversion fn
+* fix(tests): fetch matching genesis per phase
+
 # Version 0.2.0 (2025-03-05)
 
 * feat: add support for v1 of penumbra crates

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5977,7 +5977,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-reindexer"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["Penumbra Labs <team@penumbralabs.xyz"]
 description = "A reindexing tool for Penumbra ABCI event data"
 homepage = "https://penumbra.zone"
 repository = "https://github.com/penumbra-zone/reindexer"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 


### PR DESCRIPTION
Just a bit of housekeeping, to help keeping versions straight on the machines I manage.