### PR TITLE
Allow archiving against a remote node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -384,6 +384,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.4.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59a194f9d963d8099596278594b3107448656ba73831c9d8c783e613ce86da64"
+dependencies = [
+ "flate2",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8294,6 +8307,7 @@ version = "0.12.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
 dependencies = [
+ "async-compression",
  "base64 0.22.1",
  "bytes",
  "encoding_rs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1455,20 +1455,6 @@ dependencies = [
 
 [[package]]
 name = "decaf377-fmd"
-version = "0.80.6"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.80.6#94b0058158d222f82781d9cbfd98d013d1c16037"
-dependencies = [
- "ark-ff",
- "ark-serialize",
- "bitvec",
- "blake2b_simd 1.0.2",
- "decaf377",
- "rand_core",
- "thiserror",
-]
-
-[[package]]
-name = "decaf377-fmd"
 version = "0.80.12"
 source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.80.12#7bf2f9d14df1ac55a958d2a3ccb795247a51f6cc"
 dependencies = [
@@ -5900,38 +5886,6 @@ dependencies = [
 
 [[package]]
 name = "penumbra-proto"
-version = "0.80.6"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.80.6#94b0058158d222f82781d9cbfd98d013d1c16037"
-dependencies = [
- "anyhow",
- "async-trait",
- "bech32",
- "bytes",
- "chrono",
- "decaf377-fmd 0.80.6",
- "decaf377-rdsa",
- "futures",
- "hex",
- "ibc-proto 0.41.0",
- "ibc-types 0.12.1",
- "ics23 0.11.3",
- "pbjson 0.6.0",
- "pbjson-types 0.6.0",
- "pin-project",
- "prost 0.12.6",
- "serde",
- "serde_json",
- "subtle-encoding",
- "tendermint 0.34.1",
- "tendermint-proto 0.34.1",
- "tendermint-rpc",
- "thiserror",
- "tonic 0.10.2",
- "tracing",
-]
-
-[[package]]
-name = "penumbra-proto"
 version = "0.80.12"
 source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.80.12#7bf2f9d14df1ac55a958d2a3ccb795247a51f6cc"
 dependencies = [
@@ -6016,7 +5970,6 @@ dependencies = [
  "penumbra-ibc 0.79.6",
  "penumbra-ibc 0.80.12",
  "penumbra-ibc 0.81.3",
- "penumbra-proto 0.80.6",
  "penumbra-sct 0.80.12",
  "penumbra-sct 0.81.3",
  "penumbra-sdk-app",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,9 +385,9 @@ dependencies = [
 
 [[package]]
 name = "async-stream"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
 dependencies = [
  "async-stream-impl",
  "futures-core",
@@ -396,9 +396,9 @@ dependencies = [
 
 [[package]]
 name = "async-stream-impl"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote",
@@ -2014,9 +2014,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
@@ -5981,6 +5981,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
+ "async-stream",
  "async-trait",
  "clap",
  "cnidarium 0.79.6",
@@ -5991,6 +5992,7 @@ dependencies = [
  "directories",
  "escargot",
  "flate2",
+ "futures-core",
  "hex",
  "ibc-types 0.12.1",
  "penumbra-app 0.79.6",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,9 @@ penumbra-sdk-transaction-v1 = { package = "penumbra-sdk-transaction", version = 
 sha2 = { version = "0.10.8", default-features = false }
 digest = { version = "0.10.7", default-features = false }
 prost = "0.13"
+tokio-stream = "0.1.17"
+futures-core = "0.3.31"
+async-stream = "0.3.6"
 
 
 # In debug builds, nonetheless compile dependencies in release mode, for performance.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ clap = { version = "4", features = ["derive"] }
 directories = "5.0.1"
 hex = "0.4.3"
 ibc-types = "0.12.0"
-penumbra-proto = { git = "https://github.com/penumbra-zone/penumbra", features = ["tendermint"], tag = "v0.80.6" }
 serde_json = "1.0.125"
 sqlx = { version = "0.8.0", features = ["runtime-tokio", "sqlite", "postgres"] }
 tendermint-proto = { version = "0.40.1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ prost = "0.13"
 tokio-stream = "0.1.17"
 futures-core = "0.3.31"
 async-stream = "0.3.6"
+reqwest = { version = "0.12.12", features = ["gzip", "json"] }
 
 
 # In debug builds, nonetheless compile dependencies in release mode, for performance.

--- a/src/cometbft.rs
+++ b/src/cometbft.rs
@@ -460,6 +460,9 @@ impl Store for LocalStore {
     }
 }
 
+mod remote;
+pub use remote::RemoteStore;
+
 #[cfg(test)]
 mod test {
     use super::Config;

--- a/src/cometbft/remote.rs
+++ b/src/cometbft/remote.rs
@@ -1,0 +1,31 @@
+use async_trait::async_trait;
+
+use super::{Block, Genesis};
+
+/// A store which accesses a remote penumbra node's cometbft RPC.
+pub struct RemoteStore {
+    #[allow(dead_code)]
+    base_url: String,
+}
+
+impl RemoteStore {
+    /// This takes in the URL for the cometbft rpc.
+    pub fn new(base_url: String) -> Self {
+        Self { base_url }
+    }
+}
+
+#[async_trait]
+impl super::Store for RemoteStore {
+    async fn get_genesis(&self) -> anyhow::Result<Genesis> {
+        todo!()
+    }
+
+    async fn get_height_bounds(&self) -> anyhow::Result<Option<(u64, u64)>> {
+        todo!()
+    }
+
+    async fn get_block(&self, _height: u64) -> anyhow::Result<Option<Block>> {
+        todo!()
+    }
+}

--- a/src/cometbft/remote.rs
+++ b/src/cometbft/remote.rs
@@ -1,6 +1,38 @@
+use anyhow::anyhow;
 use async_trait::async_trait;
+use serde_json::Value;
 
 use super::{Block, Genesis};
+
+trait ValueExtension {
+    fn expect_key(&self, key: &str) -> anyhow::Result<&Self>;
+    fn expect_u64_string(&self) -> anyhow::Result<u64>;
+}
+
+impl ValueExtension for Value {
+    fn expect_key(&self, key: &str) -> anyhow::Result<&Self> {
+        self.get(key).ok_or(anyhow!("expected key `{}`", key))
+    }
+
+    fn expect_u64_string(&self) -> anyhow::Result<u64> {
+        let out = self.as_str().ok_or(anyhow!("expected string"))?.parse()?;
+        return Ok(out);
+    }
+}
+
+async fn request<T>(
+    url: String,
+    params: &[(&str, &str)],
+    parser: impl FnOnce(&Value) -> anyhow::Result<T>,
+) -> anyhow::Result<T> {
+    let client = reqwest::Client::new();
+    let res: Value = client.get(url).query(params).send().await?.json().await?;
+    if let Some(err) = res.get("error") {
+        return Err(anyhow!("JSON RPC error: {}", err));
+    }
+    let body = res.expect_key("result")?;
+    parser(body)
+}
 
 /// A store which accesses a remote penumbra node's cometbft RPC.
 pub struct RemoteStore {
@@ -18,14 +50,34 @@ impl RemoteStore {
 #[async_trait]
 impl super::Store for RemoteStore {
     async fn get_genesis(&self) -> anyhow::Result<Genesis> {
-        todo!()
+        let url = format!("{}/genesis", self.base_url);
+        request(url, &[], |value| {
+            value.expect_key("genesis")?.clone().try_into()
+        })
+        .await
     }
 
     async fn get_height_bounds(&self) -> anyhow::Result<Option<(u64, u64)>> {
-        todo!()
+        let url = format!("{}/status", self.base_url);
+        request(url, &[], |value| {
+            let sync_info = value.expect_key("sync_info")?;
+            let start = sync_info
+                .expect_key("earliest_block_height")?
+                .expect_u64_string()?;
+            let end = sync_info
+                .expect_key("latest_block_height")?
+                .expect_u64_string()?;
+            Ok(Some((start, end)))
+        })
+        .await
     }
 
-    async fn get_block(&self, _height: u64) -> anyhow::Result<Option<Block>> {
-        todo!()
+    async fn get_block(&self, height: u64) -> anyhow::Result<Option<Block>> {
+        let url = format!("{}/block", self.base_url);
+        request(url, &[("height", &height.to_string())], |value| {
+            let block = value.expect_key("block")?;
+            Ok(Some(block.clone().try_into()?))
+        })
+        .await
     }
 }

--- a/src/tendermint_compat.rs
+++ b/src/tendermint_compat.rs
@@ -131,7 +131,7 @@ impl TryFrom<crate::cometbft::Block> for Block {
     type Error = anyhow::Error;
 
     fn try_from(value: crate::cometbft::Block) -> Result<Self, Self::Error> {
-        Self::try_from(value.tendermint()?)
+        Self::try_from(value.tendermint_v040()?)
     }
 }
 


### PR DESCRIPTION
Now `archive --archive-file <..> --remote-rpc <..>` allows archiving by using a remote RPC to fetch blocks, which allows archiving without stopping a node. This doesn't have a "watch" mode yet. That could be added by wrapping the command with a simple sleep loop, so I'm not sure if we need to build this in per se.

This also refactors a good bit of the code in cometbft to:
- allow for different store backends generically,
- avoid a dependency on the penumbra vendored protos for blocks