### PR TITLE
Allow regen to follow a remote node

### DIFF
--- a/src/cometbft.rs
+++ b/src/cometbft.rs
@@ -332,6 +332,10 @@ pub trait Store: Send + 'static {
     ///
     /// This can be inefficient in general, so this method can be overriden.
     /// (The use-case in mind here is a remote store, where we want to fetch several blocks at once).
+    ///
+    /// This also assumes that the bounds of the store never change. With a remote store,
+    /// the node is still running, and so new blocks may arrive, and this behavior
+    /// may not be wanted.
     fn stream_blocks(&self, start: Option<u64>, end: Option<u64>) -> BlockStream<'_> {
         Box::pin(try_stream! {
             let bounds = {

--- a/src/cometbft.rs
+++ b/src/cometbft.rs
@@ -309,13 +309,13 @@ impl TryFrom<Value> for Genesis {
 }
 
 /// A stream of blocks, with their heights, allowing for errors.
-pub type BlockStream<'a> = Pin<Box<dyn Stream<Item = anyhow::Result<(u64, Block)>> + 'a>>;
+pub type BlockStream<'a> = Pin<Box<dyn Stream<Item = anyhow::Result<(u64, Block)>> + 'a + Send>>;
 
 /// A trait abstracting over a store of cometbft data.
 ///
 /// This unifies stores that read local data, and stores that read remote data.
 #[async_trait]
-pub trait Store: Send + 'static {
+pub trait Store: Sync + Send + 'static {
     /// Get the genesis file for this Generation.
     async fn get_genesis(&self) -> anyhow::Result<Genesis>;
     /// Get the height bounds for this Generation.

--- a/src/cometbft/remote.rs
+++ b/src/cometbft/remote.rs
@@ -184,6 +184,7 @@ impl super::Store for RemoteStore {
                 let request_start_time = Instant::now();
                 let next_block = this.get_block(height).await?;
                 if let Some(block) = next_block {
+                    tracing::info!(height, "new block from remote store");
                     tx.send(Ok((height, block))).await?;
                     height += 1;
                 }

--- a/src/command/regen.rs
+++ b/src/command/regen.rs
@@ -35,12 +35,12 @@ pub struct Regen {
     stop_height: Option<u64>,
     /// If set, use a given directory to store the working reindexing state.
     ///
-    /// This allow resumption of reindexing, by reusing the directory.
+    /// This allows resumption of reindexing, by reusing the directory.
     #[clap(long)]
     working_dir: Option<PathBuf>,
-    /// If set, follow a remote node, populating blocks not in the archive.
+    /// If set, poll a remote CometBFT RPC URL to fetch new blocks continuously.
     ///
-    /// If a stop height is not set, this will run regeneration indefinitely
+    /// If a stop height is not set, this will run regeneration indefinitely.
     #[clap(long)]
     follow: Option<String>,
 }

--- a/src/command/regen.rs
+++ b/src/command/regen.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use crate::{
+    cometbft::{RemoteStore, Store},
     files::{default_penumbra_home, REINDEXER_FILE_NAME},
     indexer::Indexer,
     penumbra::Regenerator,
@@ -37,6 +38,11 @@ pub struct Regen {
     /// This allow resumption of reindexing, by reusing the directory.
     #[clap(long)]
     working_dir: Option<PathBuf>,
+    /// If set, follow a remote node, populating blocks not in the archive.
+    ///
+    /// If a stop height is not set, this will run regeneration indefinitely
+    #[clap(long)]
+    follow: Option<String>,
 }
 
 impl Regen {
@@ -53,10 +59,15 @@ impl Regen {
     pub async fn run(self) -> anyhow::Result<()> {
         let archive_file = self.archive_file()?;
 
+        let store: Option<Box<dyn Store>> = match self.follow {
+            None => None,
+            Some(x) => Some(Box::new(RemoteStore::new(x))),
+        };
+
         let archive = Storage::new(Some(&archive_file), None).await?;
         let working_dir = self.working_dir.expect("TODO: generate temp dir");
         let indexer = Indexer::init(&self.database_url).await?;
-        let regenerator = Regenerator::load(&working_dir, archive, indexer).await?;
+        let regenerator = Regenerator::load(&working_dir, archive, indexer, store).await?;
 
         regenerator.run(self.start_height, self.stop_height).await
     }

--- a/src/penumbra.rs
+++ b/src/penumbra.rs
@@ -1,8 +1,12 @@
+use crate::cometbft::Store;
 use crate::tendermint_compat::{BeginBlock, Block, DeliverTx, EndBlock, Event, ResponseDeliverTx};
 use crate::{cometbft::Genesis, indexer::Indexer, storage::Storage as Archive};
 use anyhow::anyhow;
 use async_trait::async_trait;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use tokio::task::JoinHandle;
+use tokio_stream::StreamExt as _;
 
 mod v0o79;
 mod v0o80;
@@ -362,6 +366,7 @@ pub struct Regenerator {
     working_dir: PathBuf,
     archive: Archive,
     indexer: Indexer,
+    store: Option<Arc<dyn Store>>,
 }
 
 impl Regenerator {
@@ -370,6 +375,7 @@ impl Regenerator {
         working_dir: &Path,
         archive: Archive,
         indexer: Indexer,
+        store: Option<Box<dyn Store>>,
     ) -> anyhow::Result<Self> {
         let chain_id = archive.chain_id().await?;
         Ok(Self {
@@ -377,6 +383,7 @@ impl Regenerator {
             working_dir: working_dir.to_owned(),
             archive,
             indexer,
+            store: store.map(|x| x.into()),
         })
     }
 
@@ -478,15 +485,23 @@ impl Regenerator {
         last_block: Option<u64>,
     ) -> anyhow::Result<()> {
         tracing::info!("regeneration step");
-        let genesis = self
-            .archive
-            .get_genesis(genesis_height)
-            .await?
-            .ok_or(anyhow!("expected genesis before height {}", genesis_height))?;
+        // Get genesis information, possibly from the store.
+        let genesis = match self.archive.get_genesis(genesis_height).await? {
+            Some(g) => g,
+            None => {
+                let Some(store) = self.store.as_mut() else {
+                    anyhow::bail!("expected genesis at height {}", genesis_height);
+                };
+                let g = store.get_genesis().await?;
+                self.archive.put_genesis(&g).await?;
+                g
+            }
+        };
         let mut penumbra = make_a_penumbra(version, &self.working_dir).await?;
         penumbra.genesis(genesis).await?;
 
-        self.run_to_inner(penumbra, first_block, last_block).await
+        self.run_to_inner(&mut penumbra, first_block, last_block)
+            .await
     }
 
     #[tracing::instrument(skip(self))]
@@ -497,18 +512,21 @@ impl Regenerator {
         last_block: Option<u64>,
     ) -> anyhow::Result<()> {
         tracing::info!("regeneration step");
-        let penumbra = make_a_penumbra(version, &self.working_dir).await?;
-        self.run_to_inner(penumbra, first_block, last_block).await
+        let mut penumbra = make_a_penumbra(version, &self.working_dir).await?;
+        let res = self
+            .run_to_inner(&mut penumbra, first_block, last_block)
+            .await;
+        penumbra.release().await;
+        res
     }
 
     async fn run_to_inner(
         &mut self,
-        mut penumbra: APenumbra,
+        penumbra: &mut APenumbra,
         first_block: u64,
         last_block: Option<u64>,
     ) -> anyhow::Result<()> {
-        // The first block we need to process is 1 after our current height.
-        // The last block we need to process is the one dictated to us, or the one past the last
+        // First, regenerate using the blocks inside the archive.
         let last_height_in_archive = self
             .archive
             .last_height()
@@ -517,44 +535,78 @@ impl Regenerator {
         let end = last_block.unwrap_or(u64::MAX).min(last_height_in_archive);
         tracing::info!("running chain from heights {} to {}", first_block, end);
         for height in first_block..=end {
-            if height % 100 == 0 {
-                tracing::info!("reached height {}", height);
-            }
             let block: Block = self
                 .archive
                 .get_block(height)
                 .await?
                 .ok_or(anyhow!("missing block at height {}", height))?
                 .try_into()?;
-            let block_tendermint: tendermint_v0o40::Block = block.clone().into();
-            let begin_block = BeginBlock::from(block);
-            self.indexer
-                .enter_block(height, block_tendermint.header.chain_id.as_str())
-                .await?;
-            let events = penumbra.begin_block(&begin_block).await;
-            self.indexer.events(height, events, None).await?;
-            for (i, tx) in block_tendermint.data.into_iter().enumerate() {
-                let events = penumbra.deliver_tx(&DeliverTx { tx: tx.clone() }).await;
-                self.indexer
-                    .events(
-                        height,
-                        // anyhow::Error doesn't impl Clone, thus the as_ref -> map chain.
-                        #[allow(clippy::useless_asref)]
-                        events.as_ref().map(|x| x.clone()).unwrap_or_default(),
-                        Some((i, &tx, ResponseDeliverTx::with_defaults(events))),
-                    )
-                    .await?;
-            }
-            let events = penumbra
-                .end_block(&EndBlock {
-                    height: height.try_into()?,
-                })
-                .await;
-            self.indexer.events(height, events, None).await?;
-            penumbra.commit().await?;
-            self.indexer.end_block().await?;
+            self.process_block(penumbra, height, block).await?;
         }
-        penumbra.release().await;
+        let next_height = last_height_in_archive + 1;
+        let Some(store) = self.store.clone() else {
+            return Ok(());
+        };
+
+        // Set up a buffered producer of blocks.
+        const BLOCK_BUFFER_SIZE: usize = 400;
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<(u64, _)>(BLOCK_BUFFER_SIZE);
+        let producer: JoinHandle<anyhow::Result<()>> = tokio::spawn(async move {
+            let mut stream = store.stream_blocks(Some(next_height), last_block);
+            while let Some((height, block)) = stream.try_next().await? {
+                tx.send((height, block)).await?;
+            }
+            Ok(())
+        });
+        while let Some((height, block)) = rx.recv().await {
+            self.archive.put_block(&block).await?;
+            self.process_block(penumbra, height, block.try_into()?)
+                .await?;
+        }
+
+        // Make sure the producer hasn't created some kind of error.
+        producer.await??;
+
+        Ok(())
+    }
+
+    async fn process_block(
+        &mut self,
+        penumbra: &mut APenumbra,
+        height: u64,
+        block: Block,
+    ) -> anyhow::Result<()> {
+        if height % 100 == 0 {
+            tracing::info!("reached height {}", height);
+        }
+        let block_tendermint: tendermint_v0o40::Block = block.clone().into();
+        let begin_block = BeginBlock::from(block);
+        self.indexer
+            .enter_block(height, block_tendermint.header.chain_id.as_str())
+            .await?;
+        let events = penumbra.begin_block(&begin_block).await;
+        self.indexer.events(height, events, None).await?;
+        for (i, tx) in block_tendermint.data.into_iter().enumerate() {
+            let events = penumbra.deliver_tx(&DeliverTx { tx: tx.clone() }).await;
+            self.indexer
+                .events(
+                    height,
+                    // anyhow::Error doesn't impl Clone, thus the as_ref -> map chain.
+                    #[allow(clippy::useless_asref)]
+                    events.as_ref().map(|x| x.clone()).unwrap_or_default(),
+                    Some((i, &tx, ResponseDeliverTx::with_defaults(events))),
+                )
+                .await?;
+        }
+        let events = penumbra
+            .end_block(&EndBlock {
+                height: height.try_into()?,
+            })
+            .await;
+        self.indexer.events(height, events, None).await?;
+        penumbra.commit().await?;
+        self.indexer.end_block().await?;
+
         Ok(())
     }
 }

--- a/src/penumbra.rs
+++ b/src/penumbra.rs
@@ -533,7 +533,11 @@ impl Regenerator {
             .await?
             .ok_or(anyhow!("no blocks in archive"))?;
         let end = last_block.unwrap_or(u64::MAX).min(last_height_in_archive);
-        tracing::info!("running chain from heights {} to {}", first_block, end);
+        tracing::info!(
+            "running chain from heights {} to {}",
+            first_block,
+            last_block.map(|x| x.to_string()).unwrap_or("∞".to_string())
+        );
         for height in first_block..=end {
             let block: Block = self
                 .archive
@@ -548,6 +552,7 @@ impl Regenerator {
             return Ok(());
         };
 
+        tracing::info!("reached end of archive");
         // Set up a buffered producer of blocks.
         const BLOCK_BUFFER_SIZE: usize = 400;
         let (tx, mut rx) = tokio::sync::mpsc::channel::<(u64, _)>(BLOCK_BUFFER_SIZE);

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -27,6 +27,7 @@ async fn create_pool(path: Option<&Path>) -> anyhow::Result<SqlitePool> {
 }
 
 /// Storage used for the archive format.
+#[derive(Clone)]
 pub struct Storage {
     pool: SqlitePool,
 }


### PR DESCRIPTION
Now, regen takes an optional `--follow` argument. When this is set to a remote RPC, regeneration can continue past the end of the archive, using the remote store to fetch new blocks, and populate the archive on the side.