### PR TITLE
Add logging of app hashes to the indexing database

### DIFF
--- a/src/indexer/schema.sql
+++ b/src/indexer/schema.sql
@@ -54,3 +54,11 @@ CREATE OR REPLACE VIEW tx_events AS
   FROM blocks JOIN tx_results ON (blocks.rowid = tx_results.block_id)
   JOIN event_attributes ON (tx_results.rowid = event_attributes.tx_id)
   WHERE event_attributes.tx_id IS NOT NULL;
+
+CREATE SCHEMA IF NOT EXISTS debug;
+
+CREATE TABLE IF NOT EXISTS debug.app_hash (
+  rowid SERIAL PRIMARY KEY,
+  block_id BIGINT NOT NULL REFERENCES blocks(rowid),
+  hash BYTEA NOT NULL
+);

--- a/src/penumbra/v0o79.rs
+++ b/src/penumbra/v0o79.rs
@@ -69,8 +69,7 @@ impl super::Penumbra for Penumbra {
             .collect()
     }
 
-    async fn commit(&mut self) -> anyhow::Result<()> {
-        self.app.commit(self.storage.clone()).await;
-        Ok(())
+    async fn commit(&mut self) -> anyhow::Result<super::RootHash> {
+        Ok(self.app.commit(self.storage.clone()).await.0)
     }
 }

--- a/src/penumbra/v0o80.rs
+++ b/src/penumbra/v0o80.rs
@@ -69,9 +69,8 @@ impl super::Penumbra for Penumbra {
             .collect()
     }
 
-    async fn commit(&mut self) -> anyhow::Result<()> {
-        self.app.commit(self.storage.clone()).await;
-        Ok(())
+    async fn commit(&mut self) -> anyhow::Result<super::RootHash> {
+        Ok(self.app.commit(self.storage.clone()).await.0)
     }
 }
 

--- a/src/penumbra/v1o3.rs
+++ b/src/penumbra/v1o3.rs
@@ -69,9 +69,8 @@ impl super::Penumbra for Penumbra {
             .collect()
     }
 
-    async fn commit(&mut self) -> anyhow::Result<()> {
-        self.app.commit(self.storage.clone()).await;
-        Ok(())
+    async fn commit(&mut self) -> anyhow::Result<super::RootHash> {
+        Ok(self.app.commit(self.storage.clone()).await.0)
     }
 }
 

--- a/src/penumbra/v1o4.rs
+++ b/src/penumbra/v1o4.rs
@@ -69,9 +69,8 @@ impl super::Penumbra for Penumbra {
             .collect()
     }
 
-    async fn commit(&mut self) -> anyhow::Result<()> {
-        self.app.commit(self.storage.clone()).await;
-        Ok(())
+    async fn commit(&mut self) -> anyhow::Result<super::RootHash> {
+        Ok(self.app.commit(self.storage.clone()).await.0)
     }
 }
 

--- a/src/penumbra/v2.rs
+++ b/src/penumbra/v2.rs
@@ -69,9 +69,8 @@ impl super::Penumbra for Penumbra {
             .collect()
     }
 
-    async fn commit(&mut self) -> anyhow::Result<()> {
-        self.app.commit(self.storage.clone()).await;
-        Ok(())
+    async fn commit(&mut self) -> anyhow::Result<super::RootHash> {
+        Ok(self.app.commit(self.storage.clone()).await.0)
     }
 }
 


### PR DESCRIPTION
This is very useful for debugging, since we can pin point exact points where reindexing processes diverge.