### PR TITLE
Support testnet phobos 3 + some fixes to following a new testnet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1211,8 +1211,8 @@ dependencies = [
 
 [[package]]
 name = "cnidarium-component"
-version = "2.0.0-alpha.6"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.6#0893686c56ab38bd3d6b89ce1e0b681268d338f9"
+version = "2.0.0-alpha.8"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.8#f31a6178f72d8fdb29dc2548c3b3fa0677be0ae7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1534,8 +1534,8 @@ dependencies = [
 
 [[package]]
 name = "decaf377-fmd"
-version = "2.0.0-alpha.6"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.6#0893686c56ab38bd3d6b89ce1e0b681268d338f9"
+version = "2.0.0-alpha.8"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.8#f31a6178f72d8fdb29dc2548c3b3fa0677be0ae7"
 dependencies = [
  "ark-ff",
  "ark-serialize",
@@ -1618,8 +1618,8 @@ dependencies = [
 
 [[package]]
 name = "decaf377-ka"
-version = "2.0.0-alpha.6"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.6#0893686c56ab38bd3d6b89ce1e0b681268d338f9"
+version = "2.0.0-alpha.8"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.8#f31a6178f72d8fdb29dc2548c3b3fa0677be0ae7"
 dependencies = [
  "ark-ff",
  "decaf377",
@@ -6051,19 +6051,19 @@ dependencies = [
  "penumbra-sct 0.81.3",
  "penumbra-sdk-app 1.3.0",
  "penumbra-sdk-app 1.4.0",
- "penumbra-sdk-app 2.0.0-alpha.6",
+ "penumbra-sdk-app 2.0.0-alpha.8",
  "penumbra-sdk-governance 1.3.0",
  "penumbra-sdk-governance 1.4.0",
- "penumbra-sdk-governance 2.0.0-alpha.6",
+ "penumbra-sdk-governance 2.0.0-alpha.8",
  "penumbra-sdk-ibc 1.3.0",
  "penumbra-sdk-ibc 1.4.0",
- "penumbra-sdk-ibc 2.0.0-alpha.6",
+ "penumbra-sdk-ibc 2.0.0-alpha.8",
  "penumbra-sdk-sct 1.3.0",
  "penumbra-sdk-sct 1.4.0",
- "penumbra-sdk-sct 2.0.0-alpha.6",
+ "penumbra-sdk-sct 2.0.0-alpha.8",
  "penumbra-sdk-transaction 1.3.0",
  "penumbra-sdk-transaction 1.4.0",
- "penumbra-sdk-transaction 2.0.0-alpha.6",
+ "penumbra-sdk-transaction 2.0.0-alpha.8",
  "penumbra-transaction 0.80.12",
  "penumbra-transaction 0.81.3",
  "prost 0.13.5",
@@ -6341,8 +6341,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-app"
-version = "2.0.0-alpha.6"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.6#0893686c56ab38bd3d6b89ce1e0b681268d338f9"
+version = "2.0.0-alpha.8"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.8#f31a6178f72d8fdb29dc2548c3b3fa0677be0ae7"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -6354,7 +6354,7 @@ dependencies = [
  "blake2b_simd 1.0.2",
  "cfg-if",
  "cnidarium 0.83.0",
- "cnidarium-component 2.0.0-alpha.6",
+ "cnidarium-component 2.0.0-alpha.8",
  "decaf377",
  "decaf377-rdsa",
  "futures",
@@ -6367,27 +6367,27 @@ dependencies = [
  "metrics 0.24.1",
  "once_cell",
  "parking_lot",
- "penumbra-sdk-asset 2.0.0-alpha.6",
- "penumbra-sdk-auction 2.0.0-alpha.6",
- "penumbra-sdk-community-pool 2.0.0-alpha.6",
- "penumbra-sdk-compact-block 2.0.0-alpha.6",
- "penumbra-sdk-dex 2.0.0-alpha.6",
- "penumbra-sdk-distributions 2.0.0-alpha.6",
- "penumbra-sdk-fee 2.0.0-alpha.6",
- "penumbra-sdk-funding 2.0.0-alpha.6",
- "penumbra-sdk-governance 2.0.0-alpha.6",
- "penumbra-sdk-ibc 2.0.0-alpha.6",
- "penumbra-sdk-keys 2.0.0-alpha.6",
- "penumbra-sdk-num 2.0.0-alpha.6",
- "penumbra-sdk-proof-params 2.0.0-alpha.6",
- "penumbra-sdk-proto 2.0.0-alpha.6",
- "penumbra-sdk-sct 2.0.0-alpha.6",
- "penumbra-sdk-shielded-pool 2.0.0-alpha.6",
- "penumbra-sdk-stake 2.0.0-alpha.6",
- "penumbra-sdk-tct 2.0.0-alpha.6",
- "penumbra-sdk-tower-trace 2.0.0-alpha.6",
- "penumbra-sdk-transaction 2.0.0-alpha.6",
- "penumbra-sdk-txhash 2.0.0-alpha.6",
+ "penumbra-sdk-asset 2.0.0-alpha.8",
+ "penumbra-sdk-auction 2.0.0-alpha.8",
+ "penumbra-sdk-community-pool 2.0.0-alpha.8",
+ "penumbra-sdk-compact-block 2.0.0-alpha.8",
+ "penumbra-sdk-dex 2.0.0-alpha.8",
+ "penumbra-sdk-distributions 2.0.0-alpha.8",
+ "penumbra-sdk-fee 2.0.0-alpha.8",
+ "penumbra-sdk-funding 2.0.0-alpha.8",
+ "penumbra-sdk-governance 2.0.0-alpha.8",
+ "penumbra-sdk-ibc 2.0.0-alpha.8",
+ "penumbra-sdk-keys 2.0.0-alpha.8",
+ "penumbra-sdk-num 2.0.0-alpha.8",
+ "penumbra-sdk-proof-params 2.0.0-alpha.8",
+ "penumbra-sdk-proto 2.0.0-alpha.8",
+ "penumbra-sdk-sct 2.0.0-alpha.8",
+ "penumbra-sdk-shielded-pool 2.0.0-alpha.8",
+ "penumbra-sdk-stake 2.0.0-alpha.8",
+ "penumbra-sdk-tct 2.0.0-alpha.8",
+ "penumbra-sdk-tower-trace 2.0.0-alpha.8",
+ "penumbra-sdk-transaction 2.0.0-alpha.8",
+ "penumbra-sdk-txhash 2.0.0-alpha.8",
  "prost 0.13.5",
  "rand_chacha",
  "regex",
@@ -6493,8 +6493,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-asset"
-version = "2.0.0-alpha.6"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.6#0893686c56ab38bd3d6b89ce1e0b681268d338f9"
+version = "2.0.0-alpha.8"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.8#f31a6178f72d8fdb29dc2548c3b3fa0677be0ae7"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -6507,7 +6507,7 @@ dependencies = [
  "blake2b_simd 1.0.2",
  "bytes",
  "decaf377",
- "decaf377-fmd 2.0.0-alpha.6",
+ "decaf377-fmd 2.0.0-alpha.8",
  "decaf377-rdsa",
  "derivative",
  "ethnum",
@@ -6517,8 +6517,8 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "pbjson-types 0.7.0",
- "penumbra-sdk-num 2.0.0-alpha.6",
- "penumbra-sdk-proto 2.0.0-alpha.6",
+ "penumbra-sdk-num 2.0.0-alpha.8",
+ "penumbra-sdk-proto 2.0.0-alpha.8",
  "poseidon377",
  "rand",
  "rand_core",
@@ -6636,8 +6636,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-auction"
-version = "2.0.0-alpha.6"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.6#0893686c56ab38bd3d6b89ce1e0b681268d338f9"
+version = "2.0.0-alpha.8"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.8#f31a6178f72d8fdb29dc2548c3b3fa0677be0ae7"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -6653,7 +6653,7 @@ dependencies = [
  "bitvec",
  "blake2b_simd 1.0.2",
  "cnidarium 0.83.0",
- "cnidarium-component 2.0.0-alpha.6",
+ "cnidarium-component 2.0.0-alpha.8",
  "decaf377",
  "decaf377-rdsa",
  "futures",
@@ -6661,16 +6661,16 @@ dependencies = [
  "metrics 0.24.1",
  "once_cell",
  "pbjson-types 0.7.0",
- "penumbra-sdk-asset 2.0.0-alpha.6",
- "penumbra-sdk-dex 2.0.0-alpha.6",
- "penumbra-sdk-keys 2.0.0-alpha.6",
- "penumbra-sdk-num 2.0.0-alpha.6",
- "penumbra-sdk-proof-params 2.0.0-alpha.6",
- "penumbra-sdk-proto 2.0.0-alpha.6",
- "penumbra-sdk-sct 2.0.0-alpha.6",
- "penumbra-sdk-shielded-pool 2.0.0-alpha.6",
- "penumbra-sdk-tct 2.0.0-alpha.6",
- "penumbra-sdk-txhash 2.0.0-alpha.6",
+ "penumbra-sdk-asset 2.0.0-alpha.8",
+ "penumbra-sdk-dex 2.0.0-alpha.8",
+ "penumbra-sdk-keys 2.0.0-alpha.8",
+ "penumbra-sdk-num 2.0.0-alpha.8",
+ "penumbra-sdk-proof-params 2.0.0-alpha.8",
+ "penumbra-sdk-proto 2.0.0-alpha.8",
+ "penumbra-sdk-sct 2.0.0-alpha.8",
+ "penumbra-sdk-shielded-pool 2.0.0-alpha.8",
+ "penumbra-sdk-tct 2.0.0-alpha.8",
+ "penumbra-sdk-txhash 2.0.0-alpha.8",
  "prost 0.13.5",
  "prost-types 0.13.5",
  "rand_chacha",
@@ -6752,8 +6752,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-community-pool"
-version = "2.0.0-alpha.6"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.6#0893686c56ab38bd3d6b89ce1e0b681268d338f9"
+version = "2.0.0-alpha.8"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.8#f31a6178f72d8fdb29dc2548c3b3fa0677be0ae7"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -6761,19 +6761,19 @@ dependencies = [
  "base64 0.21.7",
  "blake2b_simd 1.0.2",
  "cnidarium 0.83.0",
- "cnidarium-component 2.0.0-alpha.6",
+ "cnidarium-component 2.0.0-alpha.8",
  "futures",
  "hex",
  "metrics 0.24.1",
  "once_cell",
  "pbjson-types 0.7.0",
- "penumbra-sdk-asset 2.0.0-alpha.6",
- "penumbra-sdk-keys 2.0.0-alpha.6",
- "penumbra-sdk-num 2.0.0-alpha.6",
- "penumbra-sdk-proto 2.0.0-alpha.6",
- "penumbra-sdk-sct 2.0.0-alpha.6",
- "penumbra-sdk-shielded-pool 2.0.0-alpha.6",
- "penumbra-sdk-txhash 2.0.0-alpha.6",
+ "penumbra-sdk-asset 2.0.0-alpha.8",
+ "penumbra-sdk-keys 2.0.0-alpha.8",
+ "penumbra-sdk-num 2.0.0-alpha.8",
+ "penumbra-sdk-proto 2.0.0-alpha.8",
+ "penumbra-sdk-sct 2.0.0-alpha.8",
+ "penumbra-sdk-shielded-pool 2.0.0-alpha.8",
+ "penumbra-sdk-txhash 2.0.0-alpha.8",
  "prost 0.13.5",
  "serde",
  "sha2 0.10.8",
@@ -6856,8 +6856,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-compact-block"
-version = "2.0.0-alpha.6"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.6#0893686c56ab38bd3d6b89ce1e0b681268d338f9"
+version = "2.0.0-alpha.8"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.8#f31a6178f72d8fdb29dc2548c3b3fa0677be0ae7"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -6865,21 +6865,21 @@ dependencies = [
  "blake2b_simd 1.0.2",
  "bytes",
  "cnidarium 0.83.0",
- "cnidarium-component 2.0.0-alpha.6",
+ "cnidarium-component 2.0.0-alpha.8",
  "decaf377-rdsa",
  "futures",
  "im",
  "metrics 0.24.1",
- "penumbra-sdk-dex 2.0.0-alpha.6",
- "penumbra-sdk-fee 2.0.0-alpha.6",
- "penumbra-sdk-governance 2.0.0-alpha.6",
- "penumbra-sdk-ibc 2.0.0-alpha.6",
- "penumbra-sdk-proof-params 2.0.0-alpha.6",
- "penumbra-sdk-proto 2.0.0-alpha.6",
- "penumbra-sdk-sct 2.0.0-alpha.6",
- "penumbra-sdk-shielded-pool 2.0.0-alpha.6",
- "penumbra-sdk-stake 2.0.0-alpha.6",
- "penumbra-sdk-tct 2.0.0-alpha.6",
+ "penumbra-sdk-dex 2.0.0-alpha.8",
+ "penumbra-sdk-fee 2.0.0-alpha.8",
+ "penumbra-sdk-governance 2.0.0-alpha.8",
+ "penumbra-sdk-ibc 2.0.0-alpha.8",
+ "penumbra-sdk-proof-params 2.0.0-alpha.8",
+ "penumbra-sdk-proto 2.0.0-alpha.8",
+ "penumbra-sdk-sct 2.0.0-alpha.8",
+ "penumbra-sdk-shielded-pool 2.0.0-alpha.8",
+ "penumbra-sdk-stake 2.0.0-alpha.8",
+ "penumbra-sdk-tct 2.0.0-alpha.8",
  "rand",
  "rand_core",
  "serde",
@@ -7008,8 +7008,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-dex"
-version = "2.0.0-alpha.6"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.6#0893686c56ab38bd3d6b89ce1e0b681268d338f9"
+version = "2.0.0-alpha.8"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.8#f31a6178f72d8fdb29dc2548c3b3fa0677be0ae7"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -7024,10 +7024,10 @@ dependencies = [
  "bincode",
  "blake2b_simd 1.0.2",
  "cnidarium 0.83.0",
- "cnidarium-component 2.0.0-alpha.6",
+ "cnidarium-component 2.0.0-alpha.8",
  "decaf377",
- "decaf377-fmd 2.0.0-alpha.6",
- "decaf377-ka 2.0.0-alpha.6",
+ "decaf377-fmd 2.0.0-alpha.8",
+ "decaf377-ka 2.0.0-alpha.8",
  "decaf377-rdsa",
  "futures",
  "hex",
@@ -7037,16 +7037,16 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "pbjson-types 0.7.0",
- "penumbra-sdk-asset 2.0.0-alpha.6",
- "penumbra-sdk-fee 2.0.0-alpha.6",
- "penumbra-sdk-keys 2.0.0-alpha.6",
- "penumbra-sdk-num 2.0.0-alpha.6",
- "penumbra-sdk-proof-params 2.0.0-alpha.6",
- "penumbra-sdk-proto 2.0.0-alpha.6",
- "penumbra-sdk-sct 2.0.0-alpha.6",
- "penumbra-sdk-shielded-pool 2.0.0-alpha.6",
- "penumbra-sdk-tct 2.0.0-alpha.6",
- "penumbra-sdk-txhash 2.0.0-alpha.6",
+ "penumbra-sdk-asset 2.0.0-alpha.8",
+ "penumbra-sdk-fee 2.0.0-alpha.8",
+ "penumbra-sdk-keys 2.0.0-alpha.8",
+ "penumbra-sdk-num 2.0.0-alpha.8",
+ "penumbra-sdk-proof-params 2.0.0-alpha.8",
+ "penumbra-sdk-proto 2.0.0-alpha.8",
+ "penumbra-sdk-sct 2.0.0-alpha.8",
+ "penumbra-sdk-shielded-pool 2.0.0-alpha.8",
+ "penumbra-sdk-tct 2.0.0-alpha.8",
+ "penumbra-sdk-txhash 2.0.0-alpha.8",
  "poseidon377",
  "prost 0.13.5",
  "rand_core",
@@ -7102,17 +7102,17 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-distributions"
-version = "2.0.0-alpha.6"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.6#0893686c56ab38bd3d6b89ce1e0b681268d338f9"
+version = "2.0.0-alpha.8"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.8#f31a6178f72d8fdb29dc2548c3b3fa0677be0ae7"
 dependencies = [
  "anyhow",
  "async-trait",
  "cnidarium 0.83.0",
- "cnidarium-component 2.0.0-alpha.6",
- "penumbra-sdk-asset 2.0.0-alpha.6",
- "penumbra-sdk-num 2.0.0-alpha.6",
- "penumbra-sdk-proto 2.0.0-alpha.6",
- "penumbra-sdk-sct 2.0.0-alpha.6",
+ "cnidarium-component 2.0.0-alpha.8",
+ "penumbra-sdk-asset 2.0.0-alpha.8",
+ "penumbra-sdk-num 2.0.0-alpha.8",
+ "penumbra-sdk-proto 2.0.0-alpha.8",
+ "penumbra-sdk-sct 2.0.0-alpha.8",
  "serde",
  "tendermint 0.40.3",
  "tonic 0.12.3",
@@ -7175,8 +7175,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-fee"
-version = "2.0.0-alpha.6"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.6#0893686c56ab38bd3d6b89ce1e0b681268d338f9"
+version = "2.0.0-alpha.8"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.8#f31a6178f72d8fdb29dc2548c3b3fa0677be0ae7"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -7184,14 +7184,14 @@ dependencies = [
  "blake2b_simd 1.0.2",
  "bytes",
  "cnidarium 0.83.0",
- "cnidarium-component 2.0.0-alpha.6",
+ "cnidarium-component 2.0.0-alpha.8",
  "decaf377",
  "decaf377-rdsa",
  "im",
  "metrics 0.24.1",
- "penumbra-sdk-asset 2.0.0-alpha.6",
- "penumbra-sdk-num 2.0.0-alpha.6",
- "penumbra-sdk-proto 2.0.0-alpha.6",
+ "penumbra-sdk-asset 2.0.0-alpha.8",
+ "penumbra-sdk-num 2.0.0-alpha.8",
+ "penumbra-sdk-proto 2.0.0-alpha.8",
  "rand",
  "rand_core",
  "serde",
@@ -7250,33 +7250,33 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-funding"
-version = "2.0.0-alpha.6"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.6#0893686c56ab38bd3d6b89ce1e0b681268d338f9"
+version = "2.0.0-alpha.8"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.8#f31a6178f72d8fdb29dc2548c3b3fa0677be0ae7"
 dependencies = [
  "anyhow",
  "ark-groth16",
  "async-trait",
  "base64 0.21.7",
  "cnidarium 0.83.0",
- "cnidarium-component 2.0.0-alpha.6",
+ "cnidarium-component 2.0.0-alpha.8",
  "decaf377",
  "decaf377-rdsa",
  "futures",
  "metrics 0.24.1",
- "penumbra-sdk-asset 2.0.0-alpha.6",
- "penumbra-sdk-community-pool 2.0.0-alpha.6",
- "penumbra-sdk-dex 2.0.0-alpha.6",
- "penumbra-sdk-distributions 2.0.0-alpha.6",
- "penumbra-sdk-governance 2.0.0-alpha.6",
- "penumbra-sdk-keys 2.0.0-alpha.6",
- "penumbra-sdk-num 2.0.0-alpha.6",
- "penumbra-sdk-proof-params 2.0.0-alpha.6",
- "penumbra-sdk-proto 2.0.0-alpha.6",
- "penumbra-sdk-sct 2.0.0-alpha.6",
- "penumbra-sdk-shielded-pool 2.0.0-alpha.6",
- "penumbra-sdk-stake 2.0.0-alpha.6",
- "penumbra-sdk-tct 2.0.0-alpha.6",
- "penumbra-sdk-txhash 2.0.0-alpha.6",
+ "penumbra-sdk-asset 2.0.0-alpha.8",
+ "penumbra-sdk-community-pool 2.0.0-alpha.8",
+ "penumbra-sdk-dex 2.0.0-alpha.8",
+ "penumbra-sdk-distributions 2.0.0-alpha.8",
+ "penumbra-sdk-governance 2.0.0-alpha.8",
+ "penumbra-sdk-keys 2.0.0-alpha.8",
+ "penumbra-sdk-num 2.0.0-alpha.8",
+ "penumbra-sdk-proof-params 2.0.0-alpha.8",
+ "penumbra-sdk-proto 2.0.0-alpha.8",
+ "penumbra-sdk-sct 2.0.0-alpha.8",
+ "penumbra-sdk-shielded-pool 2.0.0-alpha.8",
+ "penumbra-sdk-stake 2.0.0-alpha.8",
+ "penumbra-sdk-tct 2.0.0-alpha.8",
+ "penumbra-sdk-txhash 2.0.0-alpha.8",
  "rand",
  "serde",
  "tendermint 0.40.3",
@@ -7392,8 +7392,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-governance"
-version = "2.0.0-alpha.6"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.6#0893686c56ab38bd3d6b89ce1e0b681268d338f9"
+version = "2.0.0-alpha.8"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.8#f31a6178f72d8fdb29dc2548c3b3fa0677be0ae7"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -7408,7 +7408,7 @@ dependencies = [
  "blake2b_simd 1.0.2",
  "bytes",
  "cnidarium 0.83.0",
- "cnidarium-component 2.0.0-alpha.6",
+ "cnidarium-component 2.0.0-alpha.8",
  "decaf377",
  "decaf377-rdsa",
  "futures",
@@ -7417,18 +7417,18 @@ dependencies = [
  "metrics 0.24.1",
  "once_cell",
  "pbjson-types 0.7.0",
- "penumbra-sdk-asset 2.0.0-alpha.6",
- "penumbra-sdk-distributions 2.0.0-alpha.6",
- "penumbra-sdk-ibc 2.0.0-alpha.6",
- "penumbra-sdk-keys 2.0.0-alpha.6",
- "penumbra-sdk-num 2.0.0-alpha.6",
- "penumbra-sdk-proof-params 2.0.0-alpha.6",
- "penumbra-sdk-proto 2.0.0-alpha.6",
- "penumbra-sdk-sct 2.0.0-alpha.6",
- "penumbra-sdk-shielded-pool 2.0.0-alpha.6",
- "penumbra-sdk-stake 2.0.0-alpha.6",
- "penumbra-sdk-tct 2.0.0-alpha.6",
- "penumbra-sdk-txhash 2.0.0-alpha.6",
+ "penumbra-sdk-asset 2.0.0-alpha.8",
+ "penumbra-sdk-distributions 2.0.0-alpha.8",
+ "penumbra-sdk-ibc 2.0.0-alpha.8",
+ "penumbra-sdk-keys 2.0.0-alpha.8",
+ "penumbra-sdk-num 2.0.0-alpha.8",
+ "penumbra-sdk-proof-params 2.0.0-alpha.8",
+ "penumbra-sdk-proto 2.0.0-alpha.8",
+ "penumbra-sdk-sct 2.0.0-alpha.8",
+ "penumbra-sdk-shielded-pool 2.0.0-alpha.8",
+ "penumbra-sdk-stake 2.0.0-alpha.8",
+ "penumbra-sdk-tct 2.0.0-alpha.8",
+ "penumbra-sdk-txhash 2.0.0-alpha.8",
  "rand",
  "rand_chacha",
  "rand_core",
@@ -7519,8 +7519,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-ibc"
-version = "2.0.0-alpha.6"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.6#0893686c56ab38bd3d6b89ce1e0b681268d338f9"
+version = "2.0.0-alpha.8"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.8#f31a6178f72d8fdb29dc2548c3b3fa0677be0ae7"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -7537,11 +7537,11 @@ dependencies = [
  "num-traits",
  "once_cell",
  "pbjson-types 0.7.0",
- "penumbra-sdk-asset 2.0.0-alpha.6",
- "penumbra-sdk-num 2.0.0-alpha.6",
- "penumbra-sdk-proto 2.0.0-alpha.6",
- "penumbra-sdk-sct 2.0.0-alpha.6",
- "penumbra-sdk-txhash 2.0.0-alpha.6",
+ "penumbra-sdk-asset 2.0.0-alpha.8",
+ "penumbra-sdk-num 2.0.0-alpha.8",
+ "penumbra-sdk-proto 2.0.0-alpha.8",
+ "penumbra-sdk-sct 2.0.0-alpha.8",
+ "penumbra-sdk-txhash 2.0.0-alpha.8",
  "prost 0.13.5",
  "serde",
  "serde_json",
@@ -7644,8 +7644,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-keys"
-version = "2.0.0-alpha.6"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.6#0893686c56ab38bd3d6b89ce1e0b681268d338f9"
+version = "2.0.0-alpha.8"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.8#f31a6178f72d8fdb29dc2548c3b3fa0677be0ae7"
 dependencies = [
  "aes",
  "anyhow",
@@ -7661,8 +7661,8 @@ dependencies = [
  "bytes",
  "chacha20poly1305",
  "decaf377",
- "decaf377-fmd 2.0.0-alpha.6",
- "decaf377-ka 2.0.0-alpha.6",
+ "decaf377-fmd 2.0.0-alpha.8",
+ "decaf377-ka 2.0.0-alpha.8",
  "decaf377-rdsa",
  "derivative",
  "ethnum",
@@ -7673,9 +7673,9 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "pbkdf2",
- "penumbra-sdk-asset 2.0.0-alpha.6",
- "penumbra-sdk-proto 2.0.0-alpha.6",
- "penumbra-sdk-tct 2.0.0-alpha.6",
+ "penumbra-sdk-asset 2.0.0-alpha.8",
+ "penumbra-sdk-proto 2.0.0-alpha.8",
+ "penumbra-sdk-tct 2.0.0-alpha.8",
  "poseidon377",
  "rand",
  "rand_core",
@@ -7760,8 +7760,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-num"
-version = "2.0.0-alpha.6"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.6#0893686c56ab38bd3d6b89ce1e0b681268d338f9"
+version = "2.0.0-alpha.8"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.8#f31a6178f72d8fdb29dc2548c3b3fa0677be0ae7"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -7776,7 +7776,7 @@ dependencies = [
  "blake2b_simd 1.0.2",
  "bytes",
  "decaf377",
- "decaf377-fmd 2.0.0-alpha.6",
+ "decaf377-fmd 2.0.0-alpha.8",
  "decaf377-rdsa",
  "derivative",
  "ethnum",
@@ -7784,7 +7784,7 @@ dependencies = [
  "ibig",
  "num-bigint",
  "once_cell",
- "penumbra-sdk-proto 2.0.0-alpha.6",
+ "penumbra-sdk-proto 2.0.0-alpha.8",
  "rand",
  "rand_core",
  "regex",
@@ -7846,8 +7846,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-proof-params"
-version = "2.0.0-alpha.6"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.6#0893686c56ab38bd3d6b89ce1e0b681268d338f9"
+version = "2.0.0-alpha.8"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.8#f31a6178f72d8fdb29dc2548c3b3fa0677be0ae7"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -7929,15 +7929,15 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-proto"
-version = "2.0.0-alpha.6"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.6#0893686c56ab38bd3d6b89ce1e0b681268d338f9"
+version = "2.0.0-alpha.8"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.8#f31a6178f72d8fdb29dc2548c3b3fa0677be0ae7"
 dependencies = [
  "anyhow",
  "async-trait",
  "bech32",
  "bytes",
  "cnidarium 0.83.0",
- "decaf377-fmd 2.0.0-alpha.6",
+ "decaf377-fmd 2.0.0-alpha.8",
  "decaf377-rdsa",
  "futures",
  "hex",
@@ -8030,8 +8030,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-sct"
-version = "2.0.0-alpha.6"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.6#0893686c56ab38bd3d6b89ce1e0b681268d338f9"
+version = "2.0.0-alpha.8"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.8#f31a6178f72d8fdb29dc2548c3b3fa0677be0ae7"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -8044,7 +8044,7 @@ dependencies = [
  "bytes",
  "chrono",
  "cnidarium 0.83.0",
- "cnidarium-component 2.0.0-alpha.6",
+ "cnidarium-component 2.0.0-alpha.8",
  "decaf377",
  "decaf377-rdsa",
  "hex",
@@ -8052,10 +8052,10 @@ dependencies = [
  "metrics 0.24.1",
  "once_cell",
  "pbjson-types 0.7.0",
- "penumbra-sdk-keys 2.0.0-alpha.6",
- "penumbra-sdk-proto 2.0.0-alpha.6",
- "penumbra-sdk-tct 2.0.0-alpha.6",
- "penumbra-sdk-txhash 2.0.0-alpha.6",
+ "penumbra-sdk-keys 2.0.0-alpha.8",
+ "penumbra-sdk-proto 2.0.0-alpha.8",
+ "penumbra-sdk-tct 2.0.0-alpha.8",
+ "penumbra-sdk-txhash 2.0.0-alpha.8",
  "poseidon377",
  "rand",
  "rand_core",
@@ -8175,8 +8175,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-shielded-pool"
-version = "2.0.0-alpha.6"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.6#0893686c56ab38bd3d6b89ce1e0b681268d338f9"
+version = "2.0.0-alpha.8"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.8#f31a6178f72d8fdb29dc2548c3b3fa0677be0ae7"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -8192,10 +8192,10 @@ dependencies = [
  "bytes",
  "chacha20poly1305",
  "cnidarium 0.83.0",
- "cnidarium-component 2.0.0-alpha.6",
+ "cnidarium-component 2.0.0-alpha.8",
  "decaf377",
- "decaf377-fmd 2.0.0-alpha.6",
- "decaf377-ka 2.0.0-alpha.6",
+ "decaf377-fmd 2.0.0-alpha.8",
+ "decaf377-ka 2.0.0-alpha.8",
  "decaf377-rdsa",
  "futures",
  "hex",
@@ -8204,15 +8204,15 @@ dependencies = [
  "im",
  "metrics 0.24.1",
  "once_cell",
- "penumbra-sdk-asset 2.0.0-alpha.6",
- "penumbra-sdk-ibc 2.0.0-alpha.6",
- "penumbra-sdk-keys 2.0.0-alpha.6",
- "penumbra-sdk-num 2.0.0-alpha.6",
- "penumbra-sdk-proof-params 2.0.0-alpha.6",
- "penumbra-sdk-proto 2.0.0-alpha.6",
- "penumbra-sdk-sct 2.0.0-alpha.6",
- "penumbra-sdk-tct 2.0.0-alpha.6",
- "penumbra-sdk-txhash 2.0.0-alpha.6",
+ "penumbra-sdk-asset 2.0.0-alpha.8",
+ "penumbra-sdk-ibc 2.0.0-alpha.8",
+ "penumbra-sdk-keys 2.0.0-alpha.8",
+ "penumbra-sdk-num 2.0.0-alpha.8",
+ "penumbra-sdk-proof-params 2.0.0-alpha.8",
+ "penumbra-sdk-proto 2.0.0-alpha.8",
+ "penumbra-sdk-sct 2.0.0-alpha.8",
+ "penumbra-sdk-tct 2.0.0-alpha.8",
+ "penumbra-sdk-txhash 2.0.0-alpha.8",
  "poseidon377",
  "prost 0.13.5",
  "rand",
@@ -8329,8 +8329,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-stake"
-version = "2.0.0-alpha.6"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.6#0893686c56ab38bd3d6b89ce1e0b681268d338f9"
+version = "2.0.0-alpha.8"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.8#f31a6178f72d8fdb29dc2548c3b3fa0677be0ae7"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -8345,7 +8345,7 @@ dependencies = [
  "bech32",
  "bitvec",
  "cnidarium 0.83.0",
- "cnidarium-component 2.0.0-alpha.6",
+ "cnidarium-component 2.0.0-alpha.8",
  "decaf377",
  "decaf377-rdsa",
  "futures",
@@ -8353,16 +8353,16 @@ dependencies = [
  "im",
  "metrics 0.24.1",
  "once_cell",
- "penumbra-sdk-asset 2.0.0-alpha.6",
- "penumbra-sdk-distributions 2.0.0-alpha.6",
- "penumbra-sdk-keys 2.0.0-alpha.6",
- "penumbra-sdk-num 2.0.0-alpha.6",
- "penumbra-sdk-proof-params 2.0.0-alpha.6",
- "penumbra-sdk-proto 2.0.0-alpha.6",
- "penumbra-sdk-sct 2.0.0-alpha.6",
- "penumbra-sdk-shielded-pool 2.0.0-alpha.6",
- "penumbra-sdk-tct 2.0.0-alpha.6",
- "penumbra-sdk-txhash 2.0.0-alpha.6",
+ "penumbra-sdk-asset 2.0.0-alpha.8",
+ "penumbra-sdk-distributions 2.0.0-alpha.8",
+ "penumbra-sdk-keys 2.0.0-alpha.8",
+ "penumbra-sdk-num 2.0.0-alpha.8",
+ "penumbra-sdk-proof-params 2.0.0-alpha.8",
+ "penumbra-sdk-proto 2.0.0-alpha.8",
+ "penumbra-sdk-sct 2.0.0-alpha.8",
+ "penumbra-sdk-shielded-pool 2.0.0-alpha.8",
+ "penumbra-sdk-tct 2.0.0-alpha.8",
+ "penumbra-sdk-txhash 2.0.0-alpha.8",
  "rand_chacha",
  "rand_core",
  "regex",
@@ -8437,8 +8437,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-tct"
-version = "2.0.0-alpha.6"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.6#0893686c56ab38bd3d6b89ce1e0b681268d338f9"
+version = "2.0.0-alpha.8"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.8#f31a6178f72d8fdb29dc2548c3b3fa0677be0ae7"
 dependencies = [
  "ark-ed-on-bls12-377",
  "ark-ff",
@@ -8456,7 +8456,7 @@ dependencies = [
  "im",
  "once_cell",
  "parking_lot",
- "penumbra-sdk-proto 2.0.0-alpha.6",
+ "penumbra-sdk-proto 2.0.0-alpha.8",
  "poseidon377",
  "rand",
  "serde",
@@ -8510,8 +8510,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-tower-trace"
-version = "2.0.0-alpha.6"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.6#0893686c56ab38bd3d6b89ce1e0b681268d338f9"
+version = "2.0.0-alpha.8"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.8#f31a6178f72d8fdb29dc2548c3b3fa0677be0ae7"
 dependencies = [
  "futures",
  "hex",
@@ -8636,8 +8636,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-transaction"
-version = "2.0.0-alpha.6"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.6#0893686c56ab38bd3d6b89ce1e0b681268d338f9"
+version = "2.0.0-alpha.8"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.8#f31a6178f72d8fdb29dc2548c3b3fa0677be0ae7"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -8648,8 +8648,8 @@ dependencies = [
  "bytes",
  "chacha20poly1305",
  "decaf377",
- "decaf377-fmd 2.0.0-alpha.6",
- "decaf377-ka 2.0.0-alpha.6",
+ "decaf377-fmd 2.0.0-alpha.8",
+ "decaf377-ka 2.0.0-alpha.8",
  "decaf377-rdsa",
  "derivative",
  "hex",
@@ -8658,23 +8658,23 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "pbjson-types 0.7.0",
- "penumbra-sdk-asset 2.0.0-alpha.6",
- "penumbra-sdk-auction 2.0.0-alpha.6",
- "penumbra-sdk-community-pool 2.0.0-alpha.6",
- "penumbra-sdk-dex 2.0.0-alpha.6",
- "penumbra-sdk-fee 2.0.0-alpha.6",
- "penumbra-sdk-funding 2.0.0-alpha.6",
- "penumbra-sdk-governance 2.0.0-alpha.6",
- "penumbra-sdk-ibc 2.0.0-alpha.6",
- "penumbra-sdk-keys 2.0.0-alpha.6",
- "penumbra-sdk-num 2.0.0-alpha.6",
- "penumbra-sdk-proof-params 2.0.0-alpha.6",
- "penumbra-sdk-proto 2.0.0-alpha.6",
- "penumbra-sdk-sct 2.0.0-alpha.6",
- "penumbra-sdk-shielded-pool 2.0.0-alpha.6",
- "penumbra-sdk-stake 2.0.0-alpha.6",
- "penumbra-sdk-tct 2.0.0-alpha.6",
- "penumbra-sdk-txhash 2.0.0-alpha.6",
+ "penumbra-sdk-asset 2.0.0-alpha.8",
+ "penumbra-sdk-auction 2.0.0-alpha.8",
+ "penumbra-sdk-community-pool 2.0.0-alpha.8",
+ "penumbra-sdk-dex 2.0.0-alpha.8",
+ "penumbra-sdk-fee 2.0.0-alpha.8",
+ "penumbra-sdk-funding 2.0.0-alpha.8",
+ "penumbra-sdk-governance 2.0.0-alpha.8",
+ "penumbra-sdk-ibc 2.0.0-alpha.8",
+ "penumbra-sdk-keys 2.0.0-alpha.8",
+ "penumbra-sdk-num 2.0.0-alpha.8",
+ "penumbra-sdk-proof-params 2.0.0-alpha.8",
+ "penumbra-sdk-proto 2.0.0-alpha.8",
+ "penumbra-sdk-sct 2.0.0-alpha.8",
+ "penumbra-sdk-shielded-pool 2.0.0-alpha.8",
+ "penumbra-sdk-stake 2.0.0-alpha.8",
+ "penumbra-sdk-tct 2.0.0-alpha.8",
+ "penumbra-sdk-txhash 2.0.0-alpha.8",
  "poseidon377",
  "rand",
  "rand_core",
@@ -8717,15 +8717,15 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-txhash"
-version = "2.0.0-alpha.6"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.6#0893686c56ab38bd3d6b89ce1e0b681268d338f9"
+version = "2.0.0-alpha.8"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.8#f31a6178f72d8fdb29dc2548c3b3fa0677be0ae7"
 dependencies = [
  "anyhow",
  "blake2b_simd 1.0.2",
  "getrandom",
  "hex",
- "penumbra-sdk-proto 2.0.0-alpha.6",
- "penumbra-sdk-tct 2.0.0-alpha.6",
+ "penumbra-sdk-proto 2.0.0-alpha.8",
+ "penumbra-sdk-tct 2.0.0-alpha.8",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,11 +69,11 @@ penumbra-sdk-transaction-v1o4 = { package = "penumbra-sdk-transaction", tag = "v
 # v2.x dependencies; APP_VERSION 10
 # This still depends on cnidarium at version 0.83.0, and cargo will complain
 # if we try and add it as a dependency.
-penumbra-sdk-app-v2 = { package = "penumbra-sdk-app", git = "https://github.com/penumbra-zone/penumbra", tag = "v2.0.0-alpha.6"}
-penumbra-sdk-governance-v2 = { package = "penumbra-sdk-governance", git = "https://github.com/penumbra-zone/penumbra", tag = "v2.0.0-alpha.6"}
-penumbra-sdk-ibc-v2 = { package = "penumbra-sdk-ibc", git = "https://github.com/penumbra-zone/penumbra", tag = "v2.0.0-alpha.6"}
-penumbra-sdk-sct-v2 = { package = "penumbra-sdk-sct", git = "https://github.com/penumbra-zone/penumbra", tag = "v2.0.0-alpha.6"}
-penumbra-sdk-transaction-v2 = { package = "penumbra-sdk-transaction", git = "https://github.com/penumbra-zone/penumbra", tag = "v2.0.0-alpha.6"}
+penumbra-sdk-app-v2 = { package = "penumbra-sdk-app", git = "https://github.com/penumbra-zone/penumbra", tag = "v2.0.0-alpha.8"}
+penumbra-sdk-governance-v2 = { package = "penumbra-sdk-governance", git = "https://github.com/penumbra-zone/penumbra", tag = "v2.0.0-alpha.8"}
+penumbra-sdk-ibc-v2 = { package = "penumbra-sdk-ibc", git = "https://github.com/penumbra-zone/penumbra", tag = "v2.0.0-alpha.8"}
+penumbra-sdk-sct-v2 = { package = "penumbra-sdk-sct", git = "https://github.com/penumbra-zone/penumbra", tag = "v2.0.0-alpha.8"}
+penumbra-sdk-transaction-v2 = { package = "penumbra-sdk-transaction", git = "https://github.com/penumbra-zone/penumbra", tag = "v2.0.0-alpha.8"}
 
 sha2 = { version = "0.10.8", default-features = false }
 digest = { version = "0.10.7", default-features = false }

--- a/src/command/regen.rs
+++ b/src/command/regen.rs
@@ -64,7 +64,15 @@ impl Regen {
             Some(x) => Some(Box::new(RemoteStore::new(x))),
         };
 
-        let archive = Storage::new(Some(&archive_file), None).await?;
+        let chain_id = match store.as_ref() {
+            None => None,
+            Some(store) => {
+                let genesis = store.get_genesis().await?;
+                Some(genesis.chain_id())
+            }
+        };
+
+        let archive = Storage::new(Some(&archive_file), chain_id.as_deref()).await?;
         let working_dir = self.working_dir.expect("TODO: generate temp dir");
         let indexer = Indexer::init(&self.database_url).await?;
         let regenerator = Regenerator::load(&working_dir, archive, indexer, store).await?;

--- a/src/penumbra.rs
+++ b/src/penumbra.rs
@@ -266,7 +266,9 @@ impl RegenerationPlan {
     pub fn from_known_chain_id(chain_id: &str) -> Option<Self> {
         match chain_id {
             "penumbra-1" => Some(Self::penumbra_1()),
+            // Rest in Peace.
             "penumbra-testnet-phobos-2" => Some(Self::penumbra_testnet_phobos_2()),
+            "penumbra-testnet-phobos-3" => Some(Self::penumbra_testnet_phobos_3()),
             _ => None,
         }
     }
@@ -310,6 +312,22 @@ impl RegenerationPlan {
                     },
                 ),
             ],
+        }
+    }
+
+    pub fn penumbra_testnet_phobos_3() -> Self {
+        use RegenerationStep::*;
+        use Version::*;
+
+        Self {
+            steps: vec![(
+                0,
+                InitThenRunTo {
+                    genesis_height: 1,
+                    version: V2,
+                    last_block: None,
+                },
+            )],
         }
     }
 

--- a/src/penumbra.rs
+++ b/src/penumbra.rs
@@ -486,7 +486,11 @@ impl Regenerator {
             stop,
             plan
         );
-        plan.check_against_archive(&self.archive).await??;
+        // There's no point in checking the plan against an archive if we expect to use
+        // the remote store to populate the archive.
+        if self.store.is_none() {
+            plan.check_against_archive(&self.archive).await??;
+        }
         for (start, step) in plan.steps.into_iter() {
             use RegenerationStep::*;
             match step {


### PR DESCRIPTION
This adds a plan for the new testnet, and also makes it so that you can run:
```
penumbra-reindexer regen --working-dir ... --archive-file ... --database-url ... --follow ...
```
with an empty working directory, archive file, and a database that has merely been created, and automatically download the genesis and all the blocks from the new testnet, put them in an archive, and then regenerate the events with the output state in the working directory.

There were a few changes needed to make this work, basically omissions in the following logic that only got exercised now that we have a completely blank slate, rather than an existing archive.