### PR TITLE
Add export genesis <HEIGHT> command

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -1,5 +1,7 @@
 mod archive;
+mod export;
 mod regen;
 
 pub use archive::Archive;
+pub use export::Export;
 pub use regen::Regen;

--- a/src/command/export.rs
+++ b/src/command/export.rs
@@ -21,6 +21,9 @@ enum ExportCommands {
 #[derive(Debug, Args)]
 pub struct GenesisCmd {
     /// The block height to export the genesis for.
+    ///
+    /// To query for available genesis blocks in the archive, run:
+    /// `SELECT initial_height FROM geneses;`
     pub height: u64,
 
     /// Output file to write the genesis to.

--- a/src/command/export.rs
+++ b/src/command/export.rs
@@ -24,8 +24,10 @@ pub struct GenesisCmd {
     pub height: u64,
 
     /// Output file to write the genesis to.
+    ///
+    /// If not set, the genesis content will be printed to stdout.
     #[arg(short = 'o', long)]
-    pub output_file: PathBuf,
+    pub output_file: Option<PathBuf>,
 
     /// Path to the archive file to read from.
     #[arg(long)]
@@ -59,9 +61,12 @@ impl GenesisCmd {
         let genesis_value: serde_json::Value = serde_json::from_slice(&encoded)?;
         let genesis_json = serde_json::to_string_pretty(&genesis_value)?;
 
-        std::fs::write(&self.output_file, genesis_json)
-            .map_err(|e| anyhow::anyhow!("Failed to write genesis to file: {}", e))?;
-
+        if let Some(output_file) = &self.output_file {
+            std::fs::write(output_file, genesis_json)
+                .map_err(|e| anyhow::anyhow!("Failed to write genesis to file: {}", e))?;
+        } else {
+            println!("{}", genesis_json);
+        }
         Ok(())
     }
 }

--- a/src/command/export.rs
+++ b/src/command/export.rs
@@ -1,0 +1,67 @@
+use std::path::PathBuf;
+
+use anyhow::Result;
+use clap::{Args, Parser, Subcommand};
+
+/// Export data from the archive.
+#[derive(Debug, Parser)]
+pub struct Export {
+    #[command(subcommand)]
+    command: ExportCommands,
+}
+
+// to allow for exporting blocks, etc. later
+#[derive(Debug, Subcommand)]
+enum ExportCommands {
+    /// Export the genesis file for a specific height.
+    Genesis(GenesisCmd),
+}
+
+/// Export the genesis file for a specific height.
+#[derive(Debug, Args)]
+pub struct GenesisCmd {
+    /// The block height to export the genesis for.
+    pub height: u64,
+
+    /// Output file to write the genesis to.
+    #[arg(short = 'o', long)]
+    pub output_file: PathBuf,
+
+    /// Path to the archive file to read from.
+    #[arg(long)]
+    pub archive_file: PathBuf,
+}
+
+impl Export {
+    /// Run the export command.
+    pub async fn run(self) -> Result<()> {
+        match self.command {
+            ExportCommands::Genesis(cmd) => cmd.run().await,
+        }
+    }
+}
+
+impl GenesisCmd {
+    /// Run the genesis export command.
+    pub async fn run(&self) -> Result<()> {
+        // Initialize storage from the archive file.
+        // We make no assumption about the chain id, and this will fail if the archive is empty,
+        // which is what we want.
+        let archive = crate::storage::Storage::new(Some(&self.archive_file), None).await?;
+
+        let genesis = archive
+            .get_genesis(self.height)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("Genesis not found for height {}", self.height))?;
+
+        // This could be done more efficiently by adding methods to the underlying type here.
+        let encoded = genesis.encode()?;
+        let genesis_value: serde_json::Value = serde_json::from_slice(&encoded)?;
+        let genesis_json = serde_json::to_string_pretty(&genesis_value)?;
+
+        std::fs::write(&self.output_file, genesis_json)
+            .map_err(|e| anyhow::anyhow!("Failed to write genesis to file: {}", e))?;
+
+        Ok(())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,8 @@ pub enum Opt {
     Archive(command::Archive),
     /// Regenerate an index of events, given a historical archive.
     Regen(command::Regen),
+    /// Export data from the archive.
+    Export(command::Export),
 }
 
 impl Opt {
@@ -25,6 +27,7 @@ impl Opt {
         match self {
             Opt::Archive(x) => x.run().await,
             Opt::Regen(x) => x.run().await,
+            Opt::Export(x) => x.run().await,
         }
     }
 


### PR DESCRIPTION
This is useful for getting a genesis out of an archive file.

Usage:

```
Export the genesis file for a specific height

Usage: penumbra-reindexer export genesis --output-file <OUTPUT_FILE> --archive-file <ARCHIVE_FILE> <HEIGHT>

Arguments:
  <HEIGHT>  The block height to export the genesis for

Options:
  -o, --output-file <OUTPUT_FILE>    Output file to write the genesis to
      --archive-file <ARCHIVE_FILE>  Path to the archive file to read from
  -h, --help                         Print help
```