### PR TITLE
Add flag to allow existing data when regenerating

### DIFF
--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -4,9 +4,56 @@ use sqlx::{PgPool, Postgres, Transaction};
 
 use crate::tendermint_compat::{Event, ResponseDeliverTx};
 
+async fn fetch_block_id(
+    dbtx: &mut Transaction<'static, Postgres>,
+    height: u64,
+) -> anyhow::Result<Option<i64>> {
+    Ok(
+        sqlx::query_scalar("SELECT rowid FROM blocks WHERE height = $1")
+            .bind(i64::try_from(height)?)
+            .fetch_optional(dbtx.as_mut())
+            .await?,
+    )
+}
+
+async fn block_exists(
+    dbtx: &mut Transaction<'static, Postgres>,
+    height: u64,
+) -> anyhow::Result<bool> {
+    Ok(fetch_block_id(dbtx, height).await?.is_some())
+}
+
+async fn tx_exists(
+    dbtx: &mut Transaction<'static, Postgres>,
+    height: u64,
+    index: usize,
+) -> anyhow::Result<bool> {
+    Ok(sqlx::query_scalar(
+        "
+       SELECT EXISTS(
+           SELECT 1
+           FROM tx_results
+           JOIN blocks ON blocks.rowid = tx_results.block_id
+           WHERE height = $1
+           AND index = $2
+    )",
+    )
+    .bind(i64::try_from(height)?)
+    .bind(i64::try_from(index)?)
+    .fetch_one(dbtx.as_mut())
+    .await?)
+}
+
 struct Context {
     block_id: i64,
     dbtx: Transaction<'static, Postgres>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct IndexerOpts {
+    /// If set, will allow there to be existing data in the database, with the behavior
+    /// of not overwriting that data, and instead continuing silently.
+    pub allow_existing_data: bool,
 }
 
 /// Represents an indexer for raw ABCI events.
@@ -15,6 +62,7 @@ struct Context {
 pub struct Indexer {
     pool: PgPool,
     context: Option<Context>,
+    opts: IndexerOpts,
 }
 
 impl Drop for Indexer {
@@ -32,7 +80,7 @@ impl Drop for Indexer {
 impl Indexer {
     /// Initialize the indexer with a given database url.
     #[tracing::instrument]
-    pub async fn init(database_url: &str) -> anyhow::Result<Self> {
+    pub async fn init(database_url: &str, opts: IndexerOpts) -> anyhow::Result<Self> {
         tracing::info!("initializing database");
 
         let pool = PgPool::connect(database_url).await?;
@@ -44,6 +92,7 @@ impl Indexer {
         Ok(Self {
             pool,
             context: None,
+            opts,
         })
     }
 
@@ -55,13 +104,22 @@ impl Indexer {
         tracing::debug!(height, "indexing block");
         assert!(self.context.is_none());
         let mut dbtx = self.pool.begin().await?;
-        let (block_id,): (i64,) = sqlx::query_as(
-            "INSERT INTO blocks VALUES (DEFAULT, $1, $2, CURRENT_TIMESTAMP) RETURNING rowid",
-        )
-        .bind(i64::try_from(height)?)
-        .bind(chain_id)
-        .fetch_one(dbtx.as_mut())
-        .await?;
+        let block_id: i64 = match fetch_block_id(&mut dbtx, height).await? {
+            None => {
+                let (block_id,): (i64,) = sqlx::query_as(
+                "INSERT INTO blocks VALUES (DEFAULT, $1, $2, CURRENT_TIMESTAMP) RETURNING rowid",
+            )
+            .bind(i64::try_from(height)?)
+            .bind(chain_id)
+            .fetch_one(dbtx.as_mut())
+            .await?;
+                block_id
+            }
+            Some(id) if self.opts.allow_existing_data => id,
+            Some(_) => {
+                anyhow::bail!("block at height {} has already been indexed", height)
+            }
+        };
         self.context = Some(Context { block_id, dbtx });
         self.events(
             height,
@@ -88,11 +146,28 @@ impl Indexer {
             None => panic!("we should be inside a block before ending it"),
             Some(ctx) => ctx,
         };
-        sqlx::query("INSERT INTO debug.app_hash VALUES (DEFAULT, $1, $2)")
+        let skip = if self.opts.allow_existing_data {
+            sqlx::query_scalar(
+                "
+                SELECT EXISTS(
+                    SELECT 1
+                    FROM debug.app_hash       
+                    WHERE block_id =  $1
+                )",
+            )
             .bind(context.block_id)
-            .bind(app_hash)
-            .execute(context.dbtx.as_mut())
-            .await?;
+            .fetch_one(context.dbtx.as_mut())
+            .await?
+        } else {
+            false
+        };
+        if !skip {
+            sqlx::query("INSERT INTO debug.app_hash VALUES (DEFAULT, $1, $2)")
+                .bind(context.block_id)
+                .bind(app_hash)
+                .execute(context.dbtx.as_mut())
+                .await?;
+        }
         context.dbtx.commit().await?;
         Ok(())
     }
@@ -112,6 +187,22 @@ impl Indexer {
             None => panic!("we should be inside a block before indexing events"),
             Some(ctx) => ctx,
         };
+        if self.opts.allow_existing_data {
+            // We want to skip indexing these events if the relevant generator (i.e. the block, or the tx)
+            // has already been indexed. We do this at this level of granularity, because the underlying
+            // cometbft impl https://github.com/cometbft/cometbft/blob/e820315631a81c230e4abe9bcede8e29382e8af5/state/txindex/indexer_service.go
+            // does the same. It doesn't do one transaction per block, but rather one transaction for the events
+            // tied to the block itself, and another for each transaction.
+            if let Some((index, _, _)) = tx {
+                if tx_exists(&mut context.dbtx, height, index).await? {
+                    tracing::debug!("tx ({}, {}) exists; skipping", height, index);
+                    return Ok(());
+                }
+            } else if block_exists(&mut context.dbtx, height).await? {
+                tracing::debug!("block {} exists; skipping", height);
+                return Ok(());
+            }
+        }
         let block_id = context.block_id;
         let (pseudo_events, tx_id): (Vec<Event>, Option<i64>) = match tx {
             None => (Vec::new(), None),

--- a/src/indexer/schema.sql
+++ b/src/indexer/schema.sql
@@ -25,7 +25,7 @@ CREATE TABLE IF NOT EXISTS tx_results (
 CREATE TABLE IF NOT EXISTS events (
   rowid BIGSERIAL PRIMARY KEY,
   block_id BIGINT NOT NULL REFERENCES blocks(rowid),
-  tx_id    BIGINT NULL REFERENCES tx_results(rowid),
+  tx_id    BIGINT REFERENCES tx_results(rowid),
   type VARCHAR NOT NULL
 );
 


### PR DESCRIPTION
Adds `--allow-existing-data`, which will allow the regenerating indexer to skip indexing existing data, in a way which nonetheless allows filling in any missing data. The idea is that this allows a regenerating process to "lag behind" an actual node, which acts as a primary source of event data, in order to act as a secondary source which focuses on guaranteeing data robustness.

I tested this by regnerating against the current testnet. When running with a new state, but the same events database, the command works as expected, successfully catching up without crashing because of uniqueness constraints, and then can index events after it reaches new data.