### PR TITLE
build: add container image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
 
   nix:
     name: nix build
-    runs-on: buildjet-8vcpu-ubuntu-2204
+    runs-on: buildjet-32vcpu-ubuntu-2204
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,9 @@
 name: build
 on:
   pull_request:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   cargo:
     name: cargo build

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,73 @@
+# Workflow file to build a container image.
+name: container
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - '**[0-9]+.[0-9]+.[0-9]+*'
+  pull_request:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: buildjet-16vcpu-ubuntu-2204
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: install nix
+        uses: nixbuild/nix-quick-install-action@v28
+
+      - name: setup nix cache
+        uses: nix-community/cache-nix-action@v5
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          backend: buildjet
+
+      - name: Get version
+        id: version
+        shell: bash
+        run: |
+          VERSION="$(nix eval .#version --raw)"
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+
+          # Ensure that the `ref_name` can be used as a docker tag.
+          DOCKER_TAG="$(echo "${{ github.ref_name }}" | sed -E 's/[^a-zA-Z0-9_.-]/-/g')"
+          DOCKER_TAG="$(echo "$DOCKER_TAG" | sed -E 's/^[.-]/0/')"
+          echo "DOCKER_TAG=$DOCKER_TAG" >> $GITHUB_ENV
+
+      - name: Build container image
+        run: nix develop --command just container
+
+      - name: Log in to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Load and tag image
+        if: github.event_name != 'pull_request'
+        run: |
+          # Load the image
+          docker load < result
+
+          # Tag with version and latest
+          # docker tag penumbra-reindexer:${{ steps.version.outputs.VERSION }} ghcr.io/${{ github.repository }}:${{ steps.version.outputs.VERSION }}
+          docker tag penumbra-reindexer:${{ steps.version.outputs.VERSION }} ghcr.io/${{ github.repository }}:${{ env.DOCKER_TAG }}
+          docker tag penumbra-reindexer:${{ steps.version.outputs.VERSION }} ghcr.io/${{ github.repository }}:latest
+
+      - name: Push image
+        if: github.event_name != 'pull_request'
+        run: |
+          # docker push ghcr.io/${{ github.repository }}:${{ steps.version.outputs.VERSION }}
+          docker push ghcr.io/${{ github.repository }}:${{ env.DOCKER_TAG }}
+          docker push ghcr.io/${{ github.repository }}:latest

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build:
-    runs-on: buildjet-16vcpu-ubuntu-2204
+    runs-on: buildjet-32vcpu-ubuntu-2204
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,6 +2,10 @@ name: rust
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: cargo test

--- a/justfile
+++ b/justfile
@@ -20,3 +20,17 @@ integration:
 expensive-tests:
   REINDEXER_SQLITE_DB_FILEPATH=test_data/ephemeral-storage/network/penumbra-1/node0/reindexer_archive.bin \
     cargo nextest run --release --nocapture --features expensive-tests --test file
+
+# Build the binary via nix
+build:
+  nix build
+
+# Build the container image via nix
+container:
+  # Building container via nix...
+  nix build .#container
+  # To run this container locally:
+  #
+  #   docker load < result
+  #   docker run -it localhost/penumbra-reindexer:0.5.0 bash
+  #


### PR DESCRIPTION
Adds a container image to the repo CI. Rather than write a Containerfile from scratch, I'm leaning on the already explicitly declared nix build logic, and using that to construct the container image. Tossed in a few nice-to-haves like `curl` and `tar` and friends, which are enough to get started. 

Closes #50.