### PR TITLE
fix: add support for tls db connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10290,6 +10290,7 @@ checksum = "df51b5869f3a441595eac5e8ff14d486ff285f7b8c0df8770e49c3b56351f0f0"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki 0.103.1",
  "subtle",
@@ -10838,6 +10839,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
+ "rustls 0.23.26",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -10847,6 +10849,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "url",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -12196,6 +12199,15 @@ checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37493cadf42a2a939ed404698ded7fb378bf301b5011f973361779a3a74f8c93"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ directories = "5.0.1"
 hex = "0.4.3"
 ibc-types = "0.12.0"
 serde_json = "1.0.125"
-sqlx = { version = "0.8.0", features = ["runtime-tokio", "sqlite", "postgres"] }
+sqlx = { version = "0.8.0", features = ["runtime-tokio", "sqlite", "postgres", "tls-rustls"] }
 tendermint-proto = { version = "0.40.1", default-features = false }
 tendermint_v0o34 = { package = "tendermint", version = "0.34.0", default-features = false }
 tendermint_v0o40 = { package = "tendermint", version = "0.40.1", default-features = false }


### PR DESCRIPTION
This change makes it possible to write a dest database over a TLS connection. Generally speaking doing so is a lot slower than writing directly to a localhost connection, but given the introduction of the "follow" mode from #43, it makes more sense now.