### PR TITLE
chore: cargo update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,18 +4,12 @@ version = 4
 
 [[package]]
 name = "addr2line"
-version = "0.22.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
  "gimli",
 ]
-
-[[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "adler2"
@@ -52,7 +46,7 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -66,9 +60,9 @@ dependencies = [
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.18"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android-tzdata"
@@ -87,9 +81,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.15"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -102,43 +96,44 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.8"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.4"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
 dependencies = [
  "anstyle",
- "windows-sys 0.52.0",
+ "once_cell",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.86"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "ark-bls12-377"
@@ -167,7 +162,7 @@ dependencies = [
  "derivative",
  "digest 0.10.7",
  "rayon",
- "sha2 0.10.8",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -239,7 +234,7 @@ checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
 dependencies = [
  "num-bigint",
  "num-traits",
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.95",
  "quote",
  "syn 1.0.109",
 ]
@@ -321,7 +316,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae3281bc6d0fd7e549af32b52511e1302185bd688fd3359fa36423346ff682ea"
 dependencies = [
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.95",
  "quote",
  "syn 1.0.109",
 ]
@@ -345,15 +340,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "rayon",
 ]
 
 [[package]]
 name = "arrayref"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d151e35f61089500b617991b791fc8bfd237ae50cd5950803758a179b41e67a"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
@@ -369,9 +364,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "assert_cmd"
-version = "2.0.16"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1835b7f27878de8525dc71410b5a31cdcc5f230aed5ba5df968e09c201b23d"
+checksum = "2bd389a4b2970a01282ee455294913c0a43724daedcd1a24c3eb0ec1c1320b66"
 dependencies = [
  "anstyle",
  "bstr",
@@ -385,9 +380,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.22"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59a194f9d963d8099596278594b3107448656ba73831c9d8c783e613ce86da64"
+checksum = "b37fc50485c4f3f736a4fb14199f6d5f5ba008d7f28fe710306c92780f004c07"
 dependencies = [
  "flate2",
  "futures-core",
@@ -413,20 +408,20 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.95",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.81"
+version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
+checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.95",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -446,33 +441,31 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.12.4"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd755adf9707cf671e31d944a189be3deaaeee11c8bc1d669bb8022ac90fbd0"
+checksum = "19b756939cb2f8dc900aa6dcd505e6e2428e9cae7ff7b028c49e3946efa70878"
 dependencies = [
  "aws-lc-sys",
- "paste",
  "zeroize",
 ]
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.26.0"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9dd2e03ee80ca2822dd6ea431163d2ef259f2066a4d6ccaca6d9dcb386aa43"
+checksum = "bfa9b6986f250236c27e5a204062434a773a13243d2ffc2955f37bdba4c5c6a1"
 dependencies = [
  "bindgen 0.69.5",
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
- "paste",
 ]
 
 [[package]]
@@ -488,7 +481,7 @@ dependencies = [
  "futures-util",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.30",
+ "hyper 0.14.32",
  "itoa",
  "matchit",
  "memchr",
@@ -513,7 +506,7 @@ dependencies = [
  "axum-core 0.4.5",
  "bytes",
  "futures-util",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
  "itoa",
@@ -556,7 +549,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
  "mime",
@@ -569,17 +562,17 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.73"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
+checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
 dependencies = [
  "addr2line",
- "cc",
  "cfg-if",
  "libc",
- "miniz_oxide 0.7.4",
+ "miniz_oxide",
  "object",
  "rustc-demangle",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -602,9 +595,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.6.0"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
 
 [[package]]
 name = "bech32"
@@ -634,12 +627,12 @@ dependencies = [
  "lazycell",
  "peeking_take_while",
  "prettyplease",
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.95",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.72",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -648,7 +641,7 @@ version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "cexpr",
  "clang-sys",
  "itertools 0.12.1",
@@ -656,29 +649,48 @@ dependencies = [
  "lazycell",
  "log",
  "prettyplease",
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.95",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.72",
+ "syn 2.0.101",
  "which",
 ]
 
 [[package]]
-name = "bip32"
-version = "0.5.2"
+name = "bindgen"
+version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa13fae8b6255872fd86f7faf4b41168661d7d78609f7bfe6771b85c6739a15b"
+checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
+dependencies = [
+ "bitflags 2.9.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "proc-macro2 1.0.95",
+ "quote",
+ "regex",
+ "rustc-hash 2.1.1",
+ "shlex",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "bip32"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db40d3dfbeab4e031d78c844642fa0caa0b0db11ce1607ac9d2986dff1405c69"
 dependencies = [
  "bs58",
  "hmac",
  "k256",
  "once_cell",
  "pbkdf2",
- "rand_core",
+ "rand_core 0.6.4",
  "ripemd",
- "sha2 0.10.8",
+ "secp256k1",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -691,9 +703,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 dependencies = [
  "serde",
 ]
@@ -741,26 +753,26 @@ dependencies = [
 
 [[package]]
 name = "blake2b_simd"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23285ad32269793932e830392f2fe2f83e26488fd3ec778883a93c8323735780"
+checksum = "06e903a20b159e944f91ec8499fe1e55651480c541ea0a584f5d967c49ad9d99"
 dependencies = [
  "arrayref",
  "arrayvec 0.7.6",
- "constant_time_eq 0.3.0",
+ "constant_time_eq 0.3.1",
 ]
 
 [[package]]
 name = "blake3"
-version = "1.5.3"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9ec96fe9a81b5e365f9db71fe00edc4fe4ca2cc7dcb7861f0603012a7caa210"
+checksum = "3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0"
 dependencies = [
  "arrayref",
  "arrayvec 0.7.6",
  "cc",
  "cfg-if",
- "constant_time_eq 0.3.0",
+ "constant_time_eq 0.3.1",
 ]
 
 [[package]]
@@ -783,9 +795,9 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.5.1"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6362ed55def622cddc70a4746a68554d7b687713770de539e59a739b249f8ed"
+checksum = "ad8646f98db542e39fc66e68a20b2144f6a732636df7c2354e74645faaa433ce"
 dependencies = [
  "borsh-derive",
  "cfg_aliases",
@@ -793,16 +805,15 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "1.5.1"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3ef8005764f53cd4dca619f5bf64cafd4664dada50ece25e4d81de54c80cc0b"
+checksum = "fdd1d3c0c2f5833f22386f252fe8ed005c7f59fdcddeef025c01b4c3b9fd9ac3"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.95",
  "quote",
- "syn 2.0.72",
- "syn_derive",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -811,31 +822,31 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
 dependencies = [
- "sha2 0.10.8",
+ "sha2 0.10.9",
 ]
 
 [[package]]
 name = "bstr"
-version = "1.11.3"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531a9155a481e2ee699d4f98f43c0ca4ff8ee1bfd55c31e9e98fb29d2b176fe0"
+checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
 dependencies = [
  "memchr",
- "regex-automata 0.4.7",
+ "regex-automata 0.4.9",
  "serde",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "byte-slice-cast"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
+checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
 name = "byteorder"
@@ -845,29 +856,28 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.1"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "bzip2-sys"
-version = "0.1.11+1.0.8"
+version = "0.1.13+1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
 dependencies = [
  "cc",
- "libc",
  "pkg-config",
 ]
 
 [[package]]
 name = "cc"
-version = "1.1.13"
+version = "1.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72db2f7947ecee9b03b510377e8bb9077afa27176fdbff55c51027e976fdcc48"
+checksum = "04da6a0d40b948dfc4fa8f5bbf402b0fc1a64a28dbf7d12ffd683550f2c1b63a"
 dependencies = [
  "jobserver",
  "libc",
@@ -922,15 +932,15 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.38"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "num-traits",
  "serde",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -965,9 +975,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.16"
+version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed6719fffa43d0d87e5fd8caeab59be1554fb028cd30edc88fc4369b17971019"
+checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -975,9 +985,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.15"
+version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216aec2b177652e3846684cbfe25c9964d18ec45234f0f5da5157b207ed1aab6"
+checksum = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2"
 dependencies = [
  "anstream",
  "anstyle",
@@ -987,21 +997,21 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.13"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
 dependencies = [
  "heck 0.5.0",
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.95",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "cmake"
@@ -1027,7 +1037,7 @@ dependencies = [
  "ibc-types 0.12.1",
  "ics23 0.11.3",
  "jmt 0.10.0",
- "metrics 0.22.3",
+ "metrics 0.22.4",
  "once_cell",
  "parking_lot",
  "pbjson 0.6.0",
@@ -1036,7 +1046,7 @@ dependencies = [
  "regex",
  "rocksdb",
  "serde",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "smallvec",
  "tempfile",
  "tendermint 0.34.1",
@@ -1061,7 +1071,7 @@ dependencies = [
  "ibc-types 0.12.1",
  "ics23 0.11.3",
  "jmt 0.10.0",
- "metrics 0.22.3",
+ "metrics 0.22.4",
  "once_cell",
  "parking_lot",
  "pbjson 0.6.0",
@@ -1070,7 +1080,7 @@ dependencies = [
  "regex",
  "rocksdb",
  "serde",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "smallvec",
  "tempfile",
  "tendermint 0.34.1",
@@ -1095,7 +1105,7 @@ dependencies = [
  "ibc-types 0.12.1",
  "ics23 0.11.3",
  "jmt 0.10.0",
- "metrics 0.22.3",
+ "metrics 0.22.4",
  "once_cell",
  "parking_lot",
  "pbjson 0.6.0",
@@ -1104,7 +1114,7 @@ dependencies = [
  "regex",
  "rocksdb",
  "serde",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "smallvec",
  "tempfile",
  "tendermint 0.34.1",
@@ -1130,7 +1140,7 @@ dependencies = [
  "ibc-types 0.15.1",
  "ics23 0.12.0",
  "jmt 0.11.0",
- "metrics 0.24.1",
+ "metrics 0.24.2",
  "once_cell",
  "parking_lot",
  "pbjson 0.7.0",
@@ -1139,7 +1149,7 @@ dependencies = [
  "regex",
  "rocksdb",
  "serde",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "smallvec",
  "tempfile",
  "tendermint 0.40.3",
@@ -1223,9 +1233,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "concurrent-queue"
@@ -1243,6 +1253,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const_format"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126f97965c8ad46d6d9163268ff28432e8f6a1196a55578867832e3049df63dd"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2 1.0.95",
+ "quote",
+ "unicode-xid 0.2.6",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1250,9 +1280,9 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "constant_time_eq"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "core-foundation"
@@ -1295,9 +1325,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.13"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51e852e6dc9a5bed1fae92dd2375037bf2b768725bf3be87811edee3249d09ad"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
@@ -1328,9 +1358,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -1347,24 +1377,24 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
 name = "crypto-bigint"
@@ -1373,7 +1403,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -1396,16 +1426,16 @@ checksum = "1c359b7249347e46fb28804470d071c921156ad62b3eef5d34e2ba867533dec8"
 dependencies = [
  "byteorder",
  "digest 0.9.0",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle-ng",
  "zeroize",
 ]
 
 [[package]]
 name = "darling"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -1413,27 +1443,27 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.95",
  "quote",
  "strsim",
- "syn 2.0.72",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1457,7 +1487,7 @@ dependencies = [
  "hex",
  "num-bigint",
  "once_cell",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -1470,10 +1500,10 @@ dependencies = [
  "ark-ff",
  "ark-serialize",
  "bitvec",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "decaf377",
- "rand_core",
- "thiserror",
+ "rand_core 0.6.4",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1484,10 +1514,10 @@ dependencies = [
  "ark-ff",
  "ark-serialize",
  "bitvec",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "decaf377",
- "rand_core",
- "thiserror",
+ "rand_core 0.6.4",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1498,10 +1528,10 @@ dependencies = [
  "ark-ff",
  "ark-serialize",
  "bitvec",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "decaf377",
- "rand_core",
- "thiserror",
+ "rand_core 0.6.4",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1512,10 +1542,10 @@ dependencies = [
  "ark-ff",
  "ark-serialize",
  "bitvec",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "decaf377",
- "rand_core",
- "thiserror",
+ "rand_core 0.6.4",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1526,10 +1556,10 @@ dependencies = [
  "ark-ff",
  "ark-serialize",
  "bitvec",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "decaf377",
- "rand_core",
- "thiserror",
+ "rand_core 0.6.4",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1540,10 +1570,10 @@ dependencies = [
  "ark-ff",
  "ark-serialize",
  "bitvec",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "decaf377",
- "rand_core",
- "thiserror",
+ "rand_core 0.6.4",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1554,8 +1584,8 @@ dependencies = [
  "ark-ff",
  "decaf377",
  "hex",
- "rand_core",
- "thiserror",
+ "rand_core 0.6.4",
+ "thiserror 1.0.69",
  "zeroize",
  "zeroize_derive",
 ]
@@ -1568,8 +1598,8 @@ dependencies = [
  "ark-ff",
  "decaf377",
  "hex",
- "rand_core",
- "thiserror",
+ "rand_core 0.6.4",
+ "thiserror 1.0.69",
  "zeroize",
  "zeroize_derive",
 ]
@@ -1582,8 +1612,8 @@ dependencies = [
  "ark-ff",
  "decaf377",
  "hex",
- "rand_core",
- "thiserror",
+ "rand_core 0.6.4",
+ "thiserror 1.0.69",
  "zeroize",
  "zeroize_derive",
 ]
@@ -1596,8 +1626,8 @@ dependencies = [
  "ark-ff",
  "decaf377",
  "hex",
- "rand_core",
- "thiserror",
+ "rand_core 0.6.4",
+ "thiserror 1.0.69",
  "zeroize",
  "zeroize_derive",
 ]
@@ -1610,8 +1640,8 @@ dependencies = [
  "ark-ff",
  "decaf377",
  "hex",
- "rand_core",
- "thiserror",
+ "rand_core 0.6.4",
+ "thiserror 1.0.69",
  "zeroize",
  "zeroize_derive",
 ]
@@ -1624,8 +1654,8 @@ dependencies = [
  "ark-ff",
  "decaf377",
  "hex",
- "rand_core",
- "thiserror",
+ "rand_core 0.6.4",
+ "thiserror 1.0.69",
  "zeroize",
  "zeroize_derive",
 ]
@@ -1642,17 +1672,17 @@ dependencies = [
  "decaf377",
  "digest 0.9.0",
  "hex",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
- "thiserror",
+ "thiserror 1.0.69",
  "zeroize",
 ]
 
 [[package]]
 name = "der"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
  "pem-rfc7468",
@@ -1661,9 +1691,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.11"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
  "serde",
@@ -1675,20 +1705,20 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.95",
  "quote",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "derive_more"
-version = "0.99.18"
+version = "0.99.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
+checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
 dependencies = [
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.95",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1745,9 +1775,9 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.95",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1770,9 +1800,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.17"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
+checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
 
 [[package]]
 name = "ecdsa"
@@ -1805,16 +1835,16 @@ checksum = "3c8465edc8ee7436ffea81d21a019b16676ee3db267aa8d5a8d729581ecf998b"
 dependencies = [
  "curve25519-dalek-ng",
  "hex",
- "rand_core",
+ "rand_core 0.6.4",
  "sha2 0.9.9",
  "zeroize",
 ]
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 dependencies = [
  "serde",
 ]
@@ -1831,7 +1861,7 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -1839,18 +1869,18 @@ dependencies = [
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.34"
+version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "erased-serde"
@@ -1863,19 +1893,19 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "escargot"
-version = "0.5.13"
+version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05a3ac187a16b5382fef8c69fd1bad123c67b7cf3932240a2d43dcdd32cded88"
+checksum = "83f351750780493fc33fa0ce8ba3c7d61f9736cfa3b3bb9ee2342643ffe40211"
 dependencies = [
  "log",
  "once_cell",
@@ -1896,15 +1926,15 @@ dependencies = [
 
 [[package]]
 name = "ethnum"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90ca2580b73ab6a1f724b76ca11ab632df820fd6040c336200d2c1df7b3c82c"
+checksum = "0939f82868b77ef93ce3c3c3daf2b3c526b456741da5a1a4559e590965b6026b"
 
 [[package]]
 name = "event-listener"
-version = "5.3.1"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
+checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -1926,7 +1956,7 @@ name = "f4jumble"
 version = "0.0.0"
 source = "git+https://github.com/zcash/librustzcash?rev=2425a0869098e3b0588ccd73c42716bcf418612c#2425a0869098e3b0588ccd73c42716bcf418612c"
 dependencies = [
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
 ]
 
 [[package]]
@@ -1935,22 +1965,22 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d42773cb15447644d170be20231a3268600e0c4cea8987d013b93ac973d3cf7"
 dependencies = [
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
 ]
 
 [[package]]
 name = "fastrand"
-version = "2.1.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ff"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1973,7 +2003,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
- "rand",
+ "rand 0.8.5",
  "rustc-hex",
  "static_assertions",
 ]
@@ -1985,13 +2015,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
-name = "flate2"
-version = "1.0.35"
+name = "fixedbitset"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "flate2"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
 dependencies = [
  "crc32fast",
- "miniz_oxide 0.8.3",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -2006,9 +2042,9 @@ dependencies = [
 
 [[package]]
 name = "flume"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2023,9 +2059,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
@@ -2065,9 +2101,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2080,9 +2116,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2096,9 +2132,9 @@ checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2118,38 +2154,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.95",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2176,28 +2212,40 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
 [[package]]
-name = "gimli"
-version = "0.29.0"
+name = "getrandom"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
+]
+
+[[package]]
+name = "gimli"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "glob"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "group"
@@ -2206,7 +2254,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -2222,29 +2270,29 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.7.1",
+ "indexmap 2.9.0",
  "slab",
  "tokio",
- "tokio-util 0.7.11",
+ "tokio-util 0.7.15",
  "tracing",
 ]
 
 [[package]]
 name = "h2"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e"
+checksum = "75249d144030531f8dee69fe9cea04d3edf809a017ae445e2abdff6629e86633"
 dependencies = [
  "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.2.0",
- "indexmap 2.7.1",
+ "http 1.3.1",
+ "indexmap 2.9.0",
  "slab",
  "tokio",
- "tokio-util 0.7.11",
+ "tokio-util 0.7.15",
  "tracing",
 ]
 
@@ -2281,20 +2329,22 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
 ]
 
 [[package]]
 name = "hashlink"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
- "hashbrown 0.14.5",
+ "hashbrown 0.15.3",
 ]
 
 [[package]]
@@ -2351,11 +2401,11 @@ dependencies = [
 
 [[package]]
 name = "home"
-version = "0.5.9"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2371,9 +2421,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
+checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
 dependencies = [
  "bytes",
  "fnv",
@@ -2398,18 +2448,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.2.0",
+ "http 1.3.1",
 ]
 
 [[package]]
 name = "http-body-util"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
- "futures-util",
- "http 1.2.0",
+ "futures-core",
+ "http 1.3.1",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
@@ -2422,9 +2472,9 @@ checksum = "add0ab9360ddbd88cfeb3bd9574a1d85cfdfa14db10b3e21d3700dbc4328758f"
 
 [[package]]
 name = "httparse"
-version = "1.9.4"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "httpdate"
@@ -2434,9 +2484,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "0.14.30"
+version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a152ddd61dfaec7273fe8419ab357f33aee0d914c5f4efbf0d96fa749eea5ec9"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2465,8 +2515,8 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.7",
- "http 1.2.0",
+ "h2 0.4.9",
+ "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
  "httpdate",
@@ -2485,7 +2535,7 @@ checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
  "http 0.2.12",
- "hyper 0.14.30",
+ "hyper 0.14.32",
  "rustls 0.21.12",
  "tokio",
  "tokio-rustls 0.24.1",
@@ -2498,14 +2548,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
 dependencies = [
  "futures-util",
- "http 1.2.0",
+ "http 1.3.1",
  "hyper 1.6.0",
  "hyper-util",
- "rustls 0.23.22",
+ "rustls 0.23.26",
  "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.1",
+ "tokio-rustls 0.26.2",
  "tower-service",
 ]
 
@@ -2515,7 +2565,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper 0.14.30",
+ "hyper 0.14.32",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
@@ -2541,7 +2591,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes",
- "hyper 0.14.30",
+ "hyper 0.14.32",
  "native-tls",
  "tokio",
  "tokio-native-tls",
@@ -2565,16 +2615,17 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
+checksum = "497bbc33a26fdd4af9ed9c70d63f61cf56a938375fbb32df34db9b1cd6d643f2"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body 1.0.1",
  "hyper 1.6.0",
+ "libc",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -2584,14 +2635,15 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.60"
+version = "0.1.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
+ "log",
  "wasm-bindgen",
  "windows-core",
 ]
@@ -2703,7 +2755,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "subtle-encoding",
  "tendermint 0.34.1",
  "tendermint-proto 0.34.1",
@@ -2736,7 +2788,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "subtle-encoding",
  "tendermint 0.40.3",
  "tendermint-proto 0.40.3",
@@ -2764,7 +2816,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "subtle-encoding",
  "tendermint 0.34.1",
  "tendermint-proto 0.34.1",
@@ -2791,7 +2843,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "subtle-encoding",
  "tendermint 0.40.3",
  "tendermint-proto 0.40.3",
@@ -2823,7 +2875,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "subtle-encoding",
  "tendermint 0.34.1",
  "tendermint-light-client-verifier 0.34.1",
@@ -2858,7 +2910,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "subtle-encoding",
  "tendermint 0.40.3",
  "tendermint-light-client-verifier 0.40.3",
@@ -2891,7 +2943,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "subtle-encoding",
  "tendermint 0.34.1",
  "tendermint-proto 0.34.1",
@@ -2921,7 +2973,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "subtle-encoding",
  "tendermint 0.40.3",
  "tendermint-proto 0.40.3",
@@ -2999,7 +3051,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "subtle-encoding",
  "tendermint 0.34.1",
  "tendermint-light-client-verifier 0.34.1",
@@ -3036,7 +3088,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "subtle-encoding",
  "tendermint 0.40.3",
  "tendermint-light-client-verifier 0.40.3",
@@ -3160,7 +3212,7 @@ checksum = "d1fcc7f316b2c079dde77564a1360639c1a956a23fa96122732e416cb10717bb"
 dependencies = [
  "cfg-if",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "static_assertions",
 ]
 
@@ -3179,7 +3231,7 @@ dependencies = [
  "prost 0.12.6",
  "ripemd",
  "serde",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "sha3",
 ]
 
@@ -3198,7 +3250,7 @@ dependencies = [
  "prost 0.13.5",
  "ripemd",
  "serde",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "sha3",
 ]
 
@@ -3243,9 +3295,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locid_transform_data"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
+checksum = "7515e6d781098bf9f7205ab3fc7e9709d34554ae0b21ddbcb5febfa4bc7df11d"
 
 [[package]]
 name = "icu_normalizer"
@@ -3267,9 +3319,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+checksum = "c5e8338228bdc8ab83303f16b797e177953730f601a96c25d10cb3ab0daa0cb7"
 
 [[package]]
 name = "icu_properties"
@@ -3288,9 +3340,9 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+checksum = "85fb8799753b75aee8d2a21d7c14d9f38921b54b3dbda10f5a3c7a7b82dba5e2"
 
 [[package]]
 name = "icu_provider"
@@ -3315,9 +3367,9 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.95",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3354,8 +3406,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0acd33ff0285af998aaf9b57342af478078f53492322fafc47450e09397e0e9"
 dependencies = [
  "bitmaps",
- "rand_core",
- "rand_xoshiro",
+ "rand_core 0.6.4",
+ "rand_xoshiro 0.6.0",
  "serde",
  "sized-chunks",
  "typenum",
@@ -3382,13 +3434,13 @@ dependencies = [
 
 [[package]]
 name = "impl-trait-for-tuples"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
+checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.95",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3410,12 +3462,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.1"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.3",
  "serde",
 ]
 
@@ -3431,18 +3483,18 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
 ]
 
 [[package]]
 name = "ipnet"
-version = "2.9.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -3487,10 +3539,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "itoa"
-version = "1.0.11"
+name = "itertools"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jmt"
@@ -3509,8 +3570,8 @@ dependencies = [
  "num-derive",
  "num-traits",
  "serde",
- "sha2 0.10.8",
- "thiserror",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
  "tracing",
 ]
 
@@ -3531,39 +3592,41 @@ dependencies = [
  "num-derive",
  "num-traits",
  "serde",
- "sha2 0.10.8",
- "thiserror",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
  "tracing",
 ]
 
 [[package]]
 name = "jobserver"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
 dependencies = [
+ "getrandom 0.3.2",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.70"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "k256"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956ff9b67e26e1a6a866cb758f12c6f8746208489e3e4a4b5580802f2f0a587b"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
 dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
- "sha2 0.10.8",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3592,15 +3655,15 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.156"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5f43f184355eefb8d17fc948dbecf6c13be3c141f20d834ae842193a448c72a"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libloading"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
+checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
  "windows-targets 0.52.6",
@@ -3608,9 +3671,9 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.2.8"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+checksum = "c9627da5196e5d8ed0b0495e61e518847578da83483c37288316d9b2e03a7f72"
 
 [[package]]
 name = "libredox"
@@ -3618,9 +3681,9 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "libc",
- "redox_syscall 0.5.3",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -3641,9 +3704,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.28.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
  "cc",
  "pkg-config",
@@ -3652,9 +3715,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.19"
+version = "1.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc53a7799a7496ebc9fd29f31f7df80e83c9bda5299768af5f9e59eeea74647"
+checksum = "8b70e7a7df205e92a1a4cd9aaae7898dac0aa555503cc0a649494d0d60e7651d"
 dependencies = [
  "cc",
  "pkg-config",
@@ -3663,15 +3726,21 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
+checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
 name = "lock_api"
@@ -3685,15 +3754,15 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "lz4-sys"
-version = "1.10.0"
+version = "1.11.1+lz4-1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "109de74d5d2353660401699a4174a4ff23fcc649caf553df71933c7fb45ad868"
+checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
 dependencies = [
  "cc",
  "libc",
@@ -3732,9 +3801,9 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "metrics"
-version = "0.22.3"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2be3cbd384d4e955b231c895ce10685e3d8260c5ccffae898c96c723b0772835"
+checksum = "56d05972e8cbac2671e85aa9d04d9160d193f8bebd1a5c1a2f4542c62e65d1d0"
 dependencies = [
  "ahash",
  "portable-atomic",
@@ -3742,9 +3811,9 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a7deb012b3b2767169ff203fadb4c6b0b82b947512e5eb9e0b78c2e186ad9e3"
+checksum = "25dea7ac8057892855ec285c440160265225438c3c45072613c25a4b26e98ef5"
 dependencies = [
  "ahash",
  "portable-atomic",
@@ -3757,14 +3826,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bf4e7146e30ad172c42c39b3246864bd2d3c6396780711a1baf749cfe423e21"
 dependencies = [
  "base64 0.21.7",
- "hyper 0.14.30",
+ "hyper 0.14.32",
  "hyper-tls 0.5.0",
- "indexmap 2.7.1",
+ "indexmap 2.9.0",
  "ipnet",
- "metrics 0.22.3",
+ "metrics 0.22.4",
  "metrics-util 0.16.3",
  "quanta",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
 ]
@@ -3780,12 +3849,12 @@ dependencies = [
  "hyper 1.6.0",
  "hyper-rustls 0.27.5",
  "hyper-util",
- "indexmap 2.7.1",
+ "indexmap 2.9.0",
  "ipnet",
- "metrics 0.24.1",
- "metrics-util 0.19.0",
+ "metrics 0.24.2",
+ "metrics-util 0.19.1",
  "quanta",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
 ]
@@ -3799,7 +3868,7 @@ dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
  "hashbrown 0.14.5",
- "metrics 0.22.3",
+ "metrics 0.22.4",
  "num_cpus",
  "quanta",
  "sketches-ddsketch 0.2.2",
@@ -3807,17 +3876,17 @@ dependencies = [
 
 [[package]]
 name = "metrics-util"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbd4884b1dd24f7d6628274a2f5ae22465c337c5ba065ec9b6edccddf8acc673"
+checksum = "b8496cc523d1f94c1385dd8f0f0c2c480b2b8aeccb5b7e4485ad6365523ae376"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
- "hashbrown 0.15.2",
- "metrics 0.24.1",
+ "hashbrown 0.15.3",
+ "metrics 0.24.2",
  "quanta",
- "rand",
- "rand_xoshiro",
+ "rand 0.9.1",
+ "rand_xoshiro 0.7.0",
  "sketches-ddsketch 0.3.0",
 ]
 
@@ -3835,31 +3904,21 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.4"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
-dependencies = [
- "adler",
-]
-
-[[package]]
-name = "miniz_oxide"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
 dependencies = [
  "adler2",
 ]
 
 [[package]]
 name = "mio"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
+checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
- "hermit-abi",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
@@ -3877,9 +3936,9 @@ checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 
 [[package]]
 name = "native-tls"
-version = "0.2.12"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
 dependencies = [
  "libc",
  "log",
@@ -3934,7 +3993,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "zeroize",
 ]
@@ -3951,7 +4010,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
 dependencies = [
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.95",
  "quote",
  "syn 1.0.109",
 ]
@@ -3998,18 +4057,18 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.3"
+version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b64972346851a39438c60b341ebc01bba47464ae329e55cf343eb93964efd9"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "opaque-debug"
@@ -4019,11 +4078,11 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.66"
+version = "0.10.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
+checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -4038,22 +4097,22 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.95",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.103"
+version = "0.9.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
+checksum = "e145e1651e858e820e4860f7b9c5e169bc1d8ce1c86043be79fa7b7634821847"
 dependencies = [
  "cc",
  "libc",
@@ -4075,35 +4134,37 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.6.12"
+version = "3.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "306800abfa29c7f16596b5970a588435e3d5b3149683d00c12b699cc19f895ee"
+checksum = "c9fde3d0718baf5bc92f577d652001da0f8d54cd03a7974e118d04fc888dc23d"
 dependencies = [
  "arrayvec 0.7.6",
  "bitvec",
  "byte-slice-cast",
+ "const_format",
  "impl-trait-for-tuples",
  "parity-scale-codec-derive",
+ "rustversion",
  "serde",
 ]
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.6.12"
+version = "3.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d830939c76d294956402033aee57a6da7b438f2294eb94864c37b0569053a42c"
+checksum = "581c837bb6b9541ce7faa9377c20616e4fb7650f6b0f68bc93c827ee504fb7b3"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.95",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "parking"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -4123,7 +4184,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.3",
+ "redox_syscall",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -4226,9 +4287,9 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "peg"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "295283b02df346d1ef66052a757869b2876ac29a6bb0ac3f5f7cd44aebe40e8f"
+checksum = "9928cfca101b36ec5163e70049ee5368a8a1c3c6efc9ca9c5f9cc2f816152477"
 dependencies = [
  "peg-macros",
  "peg-runtime",
@@ -4236,20 +4297,20 @@ dependencies = [
 
 [[package]]
 name = "peg-macros"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdad6a1d9cf116a059582ce415d5f5566aabcd4008646779dab7fdc2a9a9d426"
+checksum = "6298ab04c202fa5b5d52ba03269fb7b74550b150323038878fe6c372d8280f71"
 dependencies = [
  "peg-runtime",
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.95",
  "quote",
 ]
 
 [[package]]
 name = "peg-runtime"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3aeb8f54c078314c2065ee649a7241f46b9d8e418e1a9581ba0546657d7aa3a"
+checksum = "132dca9b868d927b35b5dd728167b2dee150eb1ad686008fc71ccb298b776fca"
 
 [[package]]
 name = "pem-rfc7468"
@@ -4272,7 +4333,7 @@ dependencies = [
  "bech32",
  "bincode",
  "bitvec",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "cnidarium 0.79.7",
  "cnidarium-component 0.79.7",
  "decaf377",
@@ -4284,7 +4345,7 @@ dependencies = [
  "ics23 0.11.3",
  "im",
  "jmt 0.10.0",
- "metrics 0.22.3",
+ "metrics 0.22.4",
  "once_cell",
  "parking_lot",
  "penumbra-asset 0.79.7",
@@ -4311,19 +4372,19 @@ dependencies = [
  "penumbra-transaction 0.79.7",
  "penumbra-txhash 0.79.7",
  "prost 0.12.6",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "regex",
  "serde",
  "serde_json",
  "serde_unit_struct",
  "serde_with",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "tempfile",
  "tendermint 0.34.1",
  "tendermint-light-client-verifier 0.34.1",
  "tendermint-proto 0.34.1",
  "tokio",
- "tokio-util 0.7.11",
+ "tokio-util 0.7.15",
  "tonic 0.10.2",
  "tonic-reflection 0.10.2",
  "tonic-web 0.10.2",
@@ -4347,7 +4408,7 @@ dependencies = [
  "bech32",
  "bincode",
  "bitvec",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "cfg-if",
  "cnidarium 0.80.13",
  "cnidarium-component 0.80.13",
@@ -4360,7 +4421,7 @@ dependencies = [
  "ics23 0.11.3",
  "im",
  "jmt 0.10.0",
- "metrics 0.22.3",
+ "metrics 0.22.4",
  "once_cell",
  "parking_lot",
  "penumbra-asset 0.80.13",
@@ -4386,19 +4447,19 @@ dependencies = [
  "penumbra-transaction 0.80.13",
  "penumbra-txhash 0.80.13",
  "prost 0.12.6",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "regex",
  "serde",
  "serde_json",
  "serde_unit_struct",
  "serde_with",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "tempfile",
  "tendermint 0.34.1",
  "tendermint-light-client-verifier 0.34.1",
  "tendermint-proto 0.34.1",
  "tokio",
- "tokio-util 0.7.11",
+ "tokio-util 0.7.15",
  "tonic 0.10.2",
  "tonic-reflection 0.10.2",
  "tonic-web 0.10.2",
@@ -4422,7 +4483,7 @@ dependencies = [
  "bech32",
  "bincode",
  "bitvec",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "cfg-if",
  "cnidarium 0.81.3",
  "cnidarium-component 0.81.3",
@@ -4435,7 +4496,7 @@ dependencies = [
  "ics23 0.11.3",
  "im",
  "jmt 0.10.0",
- "metrics 0.22.3",
+ "metrics 0.22.4",
  "once_cell",
  "parking_lot",
  "penumbra-asset 0.81.3",
@@ -4461,19 +4522,19 @@ dependencies = [
  "penumbra-transaction 0.81.3",
  "penumbra-txhash 0.81.3",
  "prost 0.12.6",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "regex",
  "serde",
  "serde_json",
  "serde_unit_struct",
  "serde_with",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "tempfile",
  "tendermint 0.34.1",
  "tendermint-light-client-verifier 0.34.1",
  "tendermint-proto 0.34.1",
  "tokio",
- "tokio-util 0.7.11",
+ "tokio-util 0.7.15",
  "tonic 0.10.2",
  "tonic-reflection 0.10.2",
  "tonic-web 0.10.2",
@@ -4498,7 +4559,7 @@ dependencies = [
  "ark-std",
  "base64 0.21.7",
  "bech32",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "bytes",
  "decaf377",
  "decaf377-fmd 0.79.7",
@@ -4513,13 +4574,13 @@ dependencies = [
  "penumbra-num 0.79.7",
  "penumbra-proto 0.79.7",
  "poseidon377",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "regex",
  "serde",
  "serde_with",
- "sha2 0.10.8",
- "thiserror",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
  "tracing",
 ]
 
@@ -4536,14 +4597,14 @@ dependencies = [
  "ark-std",
  "base64 0.21.7",
  "bech32",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "bytes",
  "decaf377",
  "decaf377-fmd 0.80.13",
  "decaf377-rdsa",
  "derivative",
  "ethnum",
- "getrandom",
+ "getrandom 0.2.16",
  "hex",
  "ibig",
  "num-bigint",
@@ -4552,13 +4613,13 @@ dependencies = [
  "penumbra-num 0.80.13",
  "penumbra-proto 0.80.13",
  "poseidon377",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "regex",
  "serde",
  "serde_with",
- "sha2 0.10.8",
- "thiserror",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
  "tracing",
 ]
 
@@ -4575,14 +4636,14 @@ dependencies = [
  "ark-std",
  "base64 0.21.7",
  "bech32",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "bytes",
  "decaf377",
  "decaf377-fmd 0.81.3",
  "decaf377-rdsa",
  "derivative",
  "ethnum",
- "getrandom",
+ "getrandom 0.2.16",
  "hex",
  "ibig",
  "num-bigint",
@@ -4591,13 +4652,13 @@ dependencies = [
  "penumbra-num 0.81.3",
  "penumbra-proto 0.81.3",
  "poseidon377",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "regex",
  "serde",
  "serde_with",
- "sha2 0.10.8",
- "thiserror",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
  "tracing",
 ]
 
@@ -4618,14 +4679,14 @@ dependencies = [
  "base64 0.21.7",
  "bech32",
  "bitvec",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "cnidarium 0.79.7",
  "cnidarium-component 0.79.7",
  "decaf377",
  "decaf377-rdsa",
  "futures",
  "hex",
- "metrics 0.22.3",
+ "metrics 0.22.4",
  "once_cell",
  "pbjson-types 0.6.0",
  "penumbra-asset 0.79.7",
@@ -4640,12 +4701,12 @@ dependencies = [
  "penumbra-txhash 0.79.7",
  "prost 0.12.6",
  "prost-types 0.12.6",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
  "regex",
  "serde",
  "serde_with",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "tap",
  "tendermint 0.34.1",
  "tokio",
@@ -4670,14 +4731,14 @@ dependencies = [
  "base64 0.21.7",
  "bech32",
  "bitvec",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "cnidarium 0.80.13",
  "cnidarium-component 0.80.13",
  "decaf377",
  "decaf377-rdsa",
  "futures",
  "hex",
- "metrics 0.22.3",
+ "metrics 0.22.4",
  "once_cell",
  "pbjson-types 0.6.0",
  "penumbra-asset 0.80.13",
@@ -4692,12 +4753,12 @@ dependencies = [
  "penumbra-txhash 0.80.13",
  "prost 0.12.6",
  "prost-types 0.12.6",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
  "regex",
  "serde",
  "serde_with",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "tap",
  "tendermint 0.34.1",
  "tokio",
@@ -4722,14 +4783,14 @@ dependencies = [
  "base64 0.21.7",
  "bech32",
  "bitvec",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "cnidarium 0.81.3",
  "cnidarium-component 0.81.3",
  "decaf377",
  "decaf377-rdsa",
  "futures",
  "hex",
- "metrics 0.22.3",
+ "metrics 0.22.4",
  "once_cell",
  "pbjson-types 0.6.0",
  "penumbra-asset 0.81.3",
@@ -4744,12 +4805,12 @@ dependencies = [
  "penumbra-txhash 0.81.3",
  "prost 0.12.6",
  "prost-types 0.12.6",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
  "regex",
  "serde",
  "serde_with",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "tap",
  "tendermint 0.34.1",
  "tokio",
@@ -4766,12 +4827,12 @@ dependencies = [
  "ark-ff",
  "async-trait",
  "base64 0.21.7",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "cnidarium 0.79.7",
  "cnidarium-component 0.79.7",
  "futures",
  "hex",
- "metrics 0.22.3",
+ "metrics 0.22.4",
  "once_cell",
  "pbjson-types 0.6.0",
  "penumbra-asset 0.79.7",
@@ -4783,7 +4844,7 @@ dependencies = [
  "penumbra-txhash 0.79.7",
  "prost 0.12.6",
  "serde",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "tendermint 0.34.1",
  "tendermint-light-client-verifier 0.34.1",
  "tracing",
@@ -4798,12 +4859,12 @@ dependencies = [
  "ark-ff",
  "async-trait",
  "base64 0.21.7",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "cnidarium 0.80.13",
  "cnidarium-component 0.80.13",
  "futures",
  "hex",
- "metrics 0.22.3",
+ "metrics 0.22.4",
  "once_cell",
  "pbjson-types 0.6.0",
  "penumbra-asset 0.80.13",
@@ -4815,7 +4876,7 @@ dependencies = [
  "penumbra-txhash 0.80.13",
  "prost 0.12.6",
  "serde",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "tendermint 0.34.1",
  "tendermint-light-client-verifier 0.34.1",
  "tracing",
@@ -4830,12 +4891,12 @@ dependencies = [
  "ark-ff",
  "async-trait",
  "base64 0.21.7",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "cnidarium 0.81.3",
  "cnidarium-component 0.81.3",
  "futures",
  "hex",
- "metrics 0.22.3",
+ "metrics 0.22.4",
  "once_cell",
  "pbjson-types 0.6.0",
  "penumbra-asset 0.81.3",
@@ -4847,7 +4908,7 @@ dependencies = [
  "penumbra-txhash 0.81.3",
  "prost 0.12.6",
  "serde",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "tendermint 0.34.1",
  "tendermint-light-client-verifier 0.34.1",
  "tracing",
@@ -4861,14 +4922,14 @@ dependencies = [
  "anyhow",
  "ark-ff",
  "async-trait",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "bytes",
  "cnidarium 0.79.7",
  "cnidarium-component 0.79.7",
  "decaf377-rdsa",
  "futures",
  "im",
- "metrics 0.22.3",
+ "metrics 0.22.4",
  "penumbra-dex 0.79.7",
  "penumbra-fee 0.79.7",
  "penumbra-governance 0.79.7",
@@ -4879,8 +4940,8 @@ dependencies = [
  "penumbra-shielded-pool 0.79.7",
  "penumbra-stake 0.79.7",
  "penumbra-tct 0.79.7",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "serde",
  "tendermint 0.34.1",
  "tokio",
@@ -4897,14 +4958,14 @@ dependencies = [
  "anyhow",
  "ark-ff",
  "async-trait",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "bytes",
  "cnidarium 0.80.13",
  "cnidarium-component 0.80.13",
  "decaf377-rdsa",
  "futures",
  "im",
- "metrics 0.22.3",
+ "metrics 0.22.4",
  "penumbra-dex 0.80.13",
  "penumbra-fee 0.80.13",
  "penumbra-governance 0.80.13",
@@ -4915,8 +4976,8 @@ dependencies = [
  "penumbra-shielded-pool 0.80.13",
  "penumbra-stake 0.80.13",
  "penumbra-tct 0.80.13",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "serde",
  "tendermint 0.34.1",
  "tokio",
@@ -4933,14 +4994,14 @@ dependencies = [
  "anyhow",
  "ark-ff",
  "async-trait",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "bytes",
  "cnidarium 0.81.3",
  "cnidarium-component 0.81.3",
  "decaf377-rdsa",
  "futures",
  "im",
- "metrics 0.22.3",
+ "metrics 0.22.4",
  "penumbra-dex 0.81.3",
  "penumbra-fee 0.81.3",
  "penumbra-governance 0.81.3",
@@ -4951,8 +5012,8 @@ dependencies = [
  "penumbra-shielded-pool 0.81.3",
  "penumbra-stake 0.81.3",
  "penumbra-tct 0.81.3",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "serde",
  "tendermint 0.34.1",
  "tokio",
@@ -4977,7 +5038,7 @@ dependencies = [
  "async-trait",
  "base64 0.21.7",
  "bincode",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "cnidarium 0.79.7",
  "cnidarium-component 0.79.7",
  "decaf377",
@@ -4987,7 +5048,7 @@ dependencies = [
  "futures",
  "hex",
  "im",
- "metrics 0.22.3",
+ "metrics 0.22.4",
  "metrics-exporter-prometheus 0.13.1",
  "once_cell",
  "parking_lot",
@@ -5004,15 +5065,15 @@ dependencies = [
  "penumbra-txhash 0.79.7",
  "poseidon377",
  "prost 0.12.6",
- "rand_core",
+ "rand_core 0.6.4",
  "regex",
  "serde",
  "serde_json",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "tap",
  "tendermint 0.34.1",
  "tendermint-light-client-verifier 0.34.1",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
  "tonic 0.10.2",
@@ -5035,7 +5096,7 @@ dependencies = [
  "async-trait",
  "base64 0.21.7",
  "bincode",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "cnidarium 0.80.13",
  "cnidarium-component 0.80.13",
  "decaf377",
@@ -5045,7 +5106,7 @@ dependencies = [
  "futures",
  "hex",
  "im",
- "metrics 0.22.3",
+ "metrics 0.22.4",
  "metrics-exporter-prometheus 0.13.1",
  "once_cell",
  "parking_lot",
@@ -5062,15 +5123,15 @@ dependencies = [
  "penumbra-txhash 0.80.13",
  "poseidon377",
  "prost 0.12.6",
- "rand_core",
+ "rand_core 0.6.4",
  "regex",
  "serde",
  "serde_json",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "tap",
  "tendermint 0.34.1",
  "tendermint-light-client-verifier 0.34.1",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
  "tonic 0.10.2",
@@ -5093,7 +5154,7 @@ dependencies = [
  "async-trait",
  "base64 0.21.7",
  "bincode",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "cnidarium 0.81.3",
  "cnidarium-component 0.81.3",
  "decaf377",
@@ -5103,7 +5164,7 @@ dependencies = [
  "futures",
  "hex",
  "im",
- "metrics 0.22.3",
+ "metrics 0.22.4",
  "metrics-exporter-prometheus 0.13.1",
  "once_cell",
  "parking_lot",
@@ -5120,15 +5181,15 @@ dependencies = [
  "penumbra-txhash 0.81.3",
  "poseidon377",
  "prost 0.12.6",
- "rand_core",
+ "rand_core 0.6.4",
  "regex",
  "serde",
  "serde_json",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "tap",
  "tendermint 0.34.1",
  "tendermint-light-client-verifier 0.34.1",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
  "tonic 0.10.2",
@@ -5197,19 +5258,19 @@ dependencies = [
  "anyhow",
  "ark-ff",
  "async-trait",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "bytes",
  "cnidarium 0.79.7",
  "cnidarium-component 0.79.7",
  "decaf377",
  "decaf377-rdsa",
  "im",
- "metrics 0.22.3",
+ "metrics 0.22.4",
  "penumbra-asset 0.79.7",
  "penumbra-num 0.79.7",
  "penumbra-proto 0.79.7",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "serde",
  "tendermint 0.34.1",
  "tonic 0.10.2",
@@ -5224,19 +5285,19 @@ dependencies = [
  "anyhow",
  "ark-ff",
  "async-trait",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "bytes",
  "cnidarium 0.80.13",
  "cnidarium-component 0.80.13",
  "decaf377",
  "decaf377-rdsa",
  "im",
- "metrics 0.22.3",
+ "metrics 0.22.4",
  "penumbra-asset 0.80.13",
  "penumbra-num 0.80.13",
  "penumbra-proto 0.80.13",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "serde",
  "tendermint 0.34.1",
  "tonic 0.10.2",
@@ -5251,19 +5312,19 @@ dependencies = [
  "anyhow",
  "ark-ff",
  "async-trait",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "bytes",
  "cnidarium 0.81.3",
  "cnidarium-component 0.81.3",
  "decaf377",
  "decaf377-rdsa",
  "im",
- "metrics 0.22.3",
+ "metrics 0.22.4",
  "penumbra-asset 0.81.3",
  "penumbra-num 0.81.3",
  "penumbra-proto 0.81.3",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "serde",
  "tendermint 0.34.1",
  "tonic 0.10.2",
@@ -5280,7 +5341,7 @@ dependencies = [
  "cnidarium 0.79.7",
  "cnidarium-component 0.79.7",
  "futures",
- "metrics 0.22.3",
+ "metrics 0.22.4",
  "penumbra-asset 0.79.7",
  "penumbra-community-pool 0.79.7",
  "penumbra-distributions 0.79.7",
@@ -5304,7 +5365,7 @@ dependencies = [
  "cnidarium 0.80.13",
  "cnidarium-component 0.80.13",
  "futures",
- "metrics 0.22.3",
+ "metrics 0.22.4",
  "penumbra-asset 0.80.13",
  "penumbra-community-pool 0.80.13",
  "penumbra-distributions 0.80.13",
@@ -5328,7 +5389,7 @@ dependencies = [
  "cnidarium 0.81.3",
  "cnidarium-component 0.81.3",
  "futures",
- "metrics 0.22.3",
+ "metrics 0.22.4",
  "penumbra-asset 0.81.3",
  "penumbra-community-pool 0.81.3",
  "penumbra-distributions 0.81.3",
@@ -5357,7 +5418,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "base64 0.21.7",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "bytes",
  "cnidarium 0.79.7",
  "cnidarium-component 0.79.7",
@@ -5366,7 +5427,7 @@ dependencies = [
  "futures",
  "ibc-types 0.12.1",
  "im",
- "metrics 0.22.3",
+ "metrics 0.22.4",
  "once_cell",
  "pbjson-types 0.6.0",
  "penumbra-asset 0.79.7",
@@ -5381,15 +5442,15 @@ dependencies = [
  "penumbra-stake 0.79.7",
  "penumbra-tct 0.79.7",
  "penumbra-txhash 0.79.7",
- "rand",
- "rand_chacha",
- "rand_core",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
  "regex",
  "serde",
  "serde_json",
  "tap",
  "tendermint 0.34.1",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tonic 0.10.2",
  "tracing",
@@ -5410,7 +5471,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "base64 0.21.7",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "bytes",
  "cnidarium 0.80.13",
  "cnidarium-component 0.80.13",
@@ -5419,7 +5480,7 @@ dependencies = [
  "futures",
  "ibc-types 0.12.1",
  "im",
- "metrics 0.22.3",
+ "metrics 0.22.4",
  "once_cell",
  "pbjson-types 0.6.0",
  "penumbra-asset 0.80.13",
@@ -5434,15 +5495,15 @@ dependencies = [
  "penumbra-stake 0.80.13",
  "penumbra-tct 0.80.13",
  "penumbra-txhash 0.80.13",
- "rand",
- "rand_chacha",
- "rand_core",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
  "regex",
  "serde",
  "serde_json",
  "tap",
  "tendermint 0.34.1",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tonic 0.10.2",
  "tracing",
@@ -5463,7 +5524,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "base64 0.21.7",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "bytes",
  "cnidarium 0.81.3",
  "cnidarium-component 0.81.3",
@@ -5472,7 +5533,7 @@ dependencies = [
  "futures",
  "ibc-types 0.12.1",
  "im",
- "metrics 0.22.3",
+ "metrics 0.22.4",
  "once_cell",
  "pbjson-types 0.6.0",
  "penumbra-asset 0.81.3",
@@ -5487,15 +5548,15 @@ dependencies = [
  "penumbra-stake 0.81.3",
  "penumbra-tct 0.81.3",
  "penumbra-txhash 0.81.3",
- "rand",
- "rand_chacha",
- "rand_core",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
  "regex",
  "serde",
  "serde_json",
  "tap",
  "tendermint 0.34.1",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tonic 0.10.2",
  "tracing",
@@ -5510,14 +5571,14 @@ dependencies = [
  "ark-ff",
  "async-trait",
  "base64 0.21.7",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "cnidarium 0.79.7",
  "futures",
  "hex",
  "ibc-proto 0.41.0",
  "ibc-types 0.12.1",
  "ics23 0.11.3",
- "metrics 0.22.3",
+ "metrics 0.22.4",
  "num-traits",
  "once_cell",
  "pbjson-types 0.6.0",
@@ -5529,7 +5590,7 @@ dependencies = [
  "prost 0.12.6",
  "serde",
  "serde_json",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "tendermint 0.34.1",
  "tendermint-light-client-verifier 0.34.1",
  "time",
@@ -5547,14 +5608,14 @@ dependencies = [
  "ark-ff",
  "async-trait",
  "base64 0.21.7",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "cnidarium 0.80.13",
  "futures",
  "hex",
  "ibc-proto 0.41.0",
  "ibc-types 0.12.1",
  "ics23 0.11.3",
- "metrics 0.22.3",
+ "metrics 0.22.4",
  "num-traits",
  "once_cell",
  "pbjson-types 0.6.0",
@@ -5566,7 +5627,7 @@ dependencies = [
  "prost 0.12.6",
  "serde",
  "serde_json",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "tendermint 0.34.1",
  "tendermint-light-client-verifier 0.34.1",
  "time",
@@ -5584,14 +5645,14 @@ dependencies = [
  "ark-ff",
  "async-trait",
  "base64 0.21.7",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "cnidarium 0.81.3",
  "futures",
  "hex",
  "ibc-proto 0.41.0",
  "ibc-types 0.12.1",
  "ics23 0.11.3",
- "metrics 0.22.3",
+ "metrics 0.22.4",
  "num-traits",
  "once_cell",
  "pbjson-types 0.6.0",
@@ -5603,7 +5664,7 @@ dependencies = [
  "prost 0.12.6",
  "serde",
  "serde_json",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "tendermint 0.34.1",
  "tendermint-light-client-verifier 0.34.1",
  "time",
@@ -5627,7 +5688,7 @@ dependencies = [
  "base64 0.21.7",
  "bech32",
  "bip32",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "bytes",
  "chacha20poly1305",
  "decaf377",
@@ -5647,12 +5708,12 @@ dependencies = [
  "penumbra-proto 0.79.7",
  "penumbra-tct 0.79.7",
  "poseidon377",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "regex",
  "serde",
- "sha2 0.10.8",
- "thiserror",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
  "tracing",
 ]
 
@@ -5671,7 +5732,7 @@ dependencies = [
  "base64 0.21.7",
  "bech32",
  "bip32",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "bytes",
  "chacha20poly1305",
  "decaf377",
@@ -5691,12 +5752,12 @@ dependencies = [
  "penumbra-proto 0.80.13",
  "penumbra-tct 0.80.13",
  "poseidon377",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "regex",
  "serde",
- "sha2 0.10.8",
- "thiserror",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
  "tracing",
 ]
 
@@ -5715,7 +5776,7 @@ dependencies = [
  "base64 0.21.7",
  "bech32",
  "bip32",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "bytes",
  "chacha20poly1305",
  "decaf377",
@@ -5735,12 +5796,12 @@ dependencies = [
  "penumbra-proto 0.81.3",
  "penumbra-tct 0.81.3",
  "poseidon377",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "regex",
  "serde",
- "sha2 0.10.8",
- "thiserror",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
  "tracing",
 ]
 
@@ -5759,7 +5820,7 @@ dependencies = [
  "ark-std",
  "base64 0.21.7",
  "bech32",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "bytes",
  "decaf377",
  "decaf377-fmd 0.79.7",
@@ -5771,12 +5832,12 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "penumbra-proto 0.79.7",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "regex",
  "serde",
- "sha2 0.10.8",
- "thiserror",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
  "tracing",
 ]
 
@@ -5795,7 +5856,7 @@ dependencies = [
  "ark-std",
  "base64 0.21.7",
  "bech32",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "bytes",
  "decaf377",
  "decaf377-fmd 0.80.13",
@@ -5807,12 +5868,12 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "penumbra-proto 0.80.13",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "regex",
  "serde",
- "sha2 0.10.8",
- "thiserror",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
  "tracing",
 ]
 
@@ -5831,7 +5892,7 @@ dependencies = [
  "ark-std",
  "base64 0.21.7",
  "bech32",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "bytes",
  "decaf377",
  "decaf377-fmd 0.81.3",
@@ -5843,12 +5904,12 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "penumbra-proto 0.81.3",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "regex",
  "serde",
- "sha2 0.10.8",
- "thiserror",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
  "tracing",
 ]
 
@@ -5871,10 +5932,10 @@ dependencies = [
  "lazy_static",
  "num-bigint",
  "once_cell",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "serde",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "tracing",
 ]
 
@@ -5896,10 +5957,10 @@ dependencies = [
  "decaf377",
  "num-bigint",
  "once_cell",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "serde",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "tracing",
 ]
 
@@ -5921,10 +5982,10 @@ dependencies = [
  "decaf377",
  "num-bigint",
  "once_cell",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "serde",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "tracing",
 ]
 
@@ -5956,7 +6017,7 @@ dependencies = [
  "tendermint 0.34.1",
  "tendermint-proto 0.34.1",
  "tendermint-rpc",
- "thiserror",
+ "thiserror 1.0.69",
  "tonic 0.10.2",
  "tracing",
 ]
@@ -6067,9 +6128,9 @@ dependencies = [
  "penumbra-transaction 0.80.13",
  "penumbra-transaction 0.81.3",
  "prost 0.13.5",
- "reqwest 0.12.12",
+ "reqwest 0.12.15",
  "serde_json",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "sqlx",
  "tar",
  "tendermint 0.34.1",
@@ -6077,9 +6138,9 @@ dependencies = [
  "tendermint-proto 0.40.3",
  "tokio",
  "tokio-stream",
- "toml 0.8.19",
+ "toml 0.8.22",
  "tracing",
- "tracing-subscriber 0.3.18",
+ "tracing-subscriber 0.3.19",
  "url",
 ]
 
@@ -6095,7 +6156,7 @@ dependencies = [
  "ark-serialize",
  "async-trait",
  "bincode",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "bytes",
  "chrono",
  "cnidarium 0.79.7",
@@ -6104,15 +6165,15 @@ dependencies = [
  "decaf377-rdsa",
  "hex",
  "im",
- "metrics 0.22.3",
+ "metrics 0.22.4",
  "once_cell",
  "pbjson-types 0.6.0",
  "penumbra-keys 0.79.7",
  "penumbra-proto 0.79.7",
  "penumbra-tct 0.79.7",
  "poseidon377",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "serde",
  "tendermint 0.34.1",
  "tonic 0.10.2",
@@ -6131,7 +6192,7 @@ dependencies = [
  "ark-serialize",
  "async-trait",
  "bincode",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "bytes",
  "chrono",
  "cnidarium 0.80.13",
@@ -6140,15 +6201,15 @@ dependencies = [
  "decaf377-rdsa",
  "hex",
  "im",
- "metrics 0.22.3",
+ "metrics 0.22.4",
  "once_cell",
  "pbjson-types 0.6.0",
  "penumbra-keys 0.80.13",
  "penumbra-proto 0.80.13",
  "penumbra-tct 0.80.13",
  "poseidon377",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "serde",
  "tendermint 0.34.1",
  "tonic 0.10.2",
@@ -6167,7 +6228,7 @@ dependencies = [
  "ark-serialize",
  "async-trait",
  "bincode",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "bytes",
  "chrono",
  "cnidarium 0.81.3",
@@ -6176,15 +6237,15 @@ dependencies = [
  "decaf377-rdsa",
  "hex",
  "im",
- "metrics 0.22.3",
+ "metrics 0.22.4",
  "once_cell",
  "pbjson-types 0.6.0",
  "penumbra-keys 0.81.3",
  "penumbra-proto 0.81.3",
  "penumbra-tct 0.81.3",
  "poseidon377",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "serde",
  "tendermint 0.34.1",
  "tonic 0.10.2",
@@ -6203,7 +6264,7 @@ dependencies = [
  "bech32",
  "bincode",
  "bitvec",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "cfg-if",
  "cnidarium 0.83.0",
  "cnidarium-component 1.3.2",
@@ -6216,7 +6277,7 @@ dependencies = [
  "ics23 0.12.0",
  "im",
  "jmt 0.11.0",
- "metrics 0.24.1",
+ "metrics 0.24.2",
  "once_cell",
  "parking_lot",
  "penumbra-sdk-asset 1.3.2",
@@ -6241,19 +6302,19 @@ dependencies = [
  "penumbra-sdk-transaction 1.3.2",
  "penumbra-sdk-txhash 1.3.2",
  "prost 0.13.5",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "regex",
  "serde",
  "serde_json",
  "serde_unit_struct",
  "serde_with",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "tempfile",
  "tendermint 0.40.3",
  "tendermint-light-client-verifier 0.40.3",
  "tendermint-proto 0.40.3",
  "tokio",
- "tokio-util 0.7.11",
+ "tokio-util 0.7.15",
  "tonic 0.12.3",
  "tonic-reflection 0.12.3",
  "tonic-web 0.12.3",
@@ -6277,7 +6338,7 @@ dependencies = [
  "bech32",
  "bincode",
  "bitvec",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "cfg-if",
  "cnidarium 0.83.0",
  "cnidarium-component 1.5.1",
@@ -6290,7 +6351,7 @@ dependencies = [
  "ics23 0.12.0",
  "im",
  "jmt 0.11.0",
- "metrics 0.24.1",
+ "metrics 0.24.2",
  "once_cell",
  "parking_lot",
  "penumbra-sdk-asset 1.5.1",
@@ -6315,19 +6376,19 @@ dependencies = [
  "penumbra-sdk-transaction 1.5.1",
  "penumbra-sdk-txhash 1.5.1",
  "prost 0.13.5",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "regex",
  "serde",
  "serde_json",
  "serde_unit_struct",
  "serde_with",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "tempfile",
  "tendermint 0.40.3",
  "tendermint-light-client-verifier 0.40.3",
  "tendermint-proto 0.40.3",
  "tokio",
- "tokio-util 0.7.11",
+ "tokio-util 0.7.15",
  "tonic 0.12.3",
  "tonic-reflection 0.12.3",
  "tonic-web 0.12.3",
@@ -6351,7 +6412,7 @@ dependencies = [
  "bech32",
  "bincode",
  "bitvec",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "cfg-if",
  "cnidarium 0.83.0",
  "cnidarium-component 2.0.0-alpha.10",
@@ -6364,7 +6425,7 @@ dependencies = [
  "ics23 0.12.0",
  "im",
  "jmt 0.11.0",
- "metrics 0.24.1",
+ "metrics 0.24.2",
  "once_cell",
  "parking_lot",
  "penumbra-sdk-asset 2.0.0-alpha.10",
@@ -6389,19 +6450,19 @@ dependencies = [
  "penumbra-sdk-transaction 2.0.0-alpha.10",
  "penumbra-sdk-txhash 2.0.0-alpha.10",
  "prost 0.13.5",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "regex",
  "serde",
  "serde_json",
  "serde_unit_struct",
  "serde_with",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "tempfile",
  "tendermint 0.40.3",
  "tendermint-light-client-verifier 0.40.3",
  "tendermint-proto 0.40.3",
  "tokio",
- "tokio-util 0.7.11",
+ "tokio-util 0.7.15",
  "tonic 0.12.3",
  "tonic-reflection 0.12.3",
  "tonic-web 0.12.3",
@@ -6426,14 +6487,14 @@ dependencies = [
  "ark-std",
  "base64 0.21.7",
  "bech32",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "bytes",
  "decaf377",
  "decaf377-fmd 1.3.2",
  "decaf377-rdsa",
  "derivative",
  "ethnum",
- "getrandom",
+ "getrandom 0.2.16",
  "hex",
  "ibig",
  "num-bigint",
@@ -6442,13 +6503,13 @@ dependencies = [
  "penumbra-sdk-num 1.3.2",
  "penumbra-sdk-proto 1.3.2",
  "poseidon377",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "regex",
  "serde",
  "serde_with",
- "sha2 0.10.8",
- "thiserror",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
  "tracing",
 ]
 
@@ -6465,14 +6526,14 @@ dependencies = [
  "ark-std",
  "base64 0.21.7",
  "bech32",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "bytes",
  "decaf377",
  "decaf377-fmd 1.5.1",
  "decaf377-rdsa",
  "derivative",
  "ethnum",
- "getrandom",
+ "getrandom 0.2.16",
  "hex",
  "ibig",
  "lazy_static",
@@ -6482,13 +6543,13 @@ dependencies = [
  "penumbra-sdk-num 1.5.1",
  "penumbra-sdk-proto 1.5.1",
  "poseidon377",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "regex",
  "serde",
  "serde_with",
- "sha2 0.10.8",
- "thiserror",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
  "tracing",
 ]
 
@@ -6505,14 +6566,14 @@ dependencies = [
  "ark-std",
  "base64 0.21.7",
  "bech32",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "bytes",
  "decaf377",
  "decaf377-fmd 2.0.0-alpha.10",
  "decaf377-rdsa",
  "derivative",
  "ethnum",
- "getrandom",
+ "getrandom 0.2.16",
  "hex",
  "ibig",
  "lazy_static",
@@ -6522,13 +6583,13 @@ dependencies = [
  "penumbra-sdk-num 2.0.0-alpha.10",
  "penumbra-sdk-proto 2.0.0-alpha.10",
  "poseidon377",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "regex",
  "serde",
  "serde_with",
- "sha2 0.10.8",
- "thiserror",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
  "tracing",
 ]
 
@@ -6549,14 +6610,14 @@ dependencies = [
  "base64 0.21.7",
  "bech32",
  "bitvec",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "cnidarium 0.83.0",
  "cnidarium-component 1.3.2",
  "decaf377",
  "decaf377-rdsa",
  "futures",
  "hex",
- "metrics 0.24.1",
+ "metrics 0.24.2",
  "once_cell",
  "pbjson-types 0.7.0",
  "penumbra-sdk-asset 1.3.2",
@@ -6571,12 +6632,12 @@ dependencies = [
  "penumbra-sdk-txhash 1.3.2",
  "prost 0.13.5",
  "prost-types 0.13.5",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
  "regex",
  "serde",
  "serde_with",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "tap",
  "tendermint 0.40.3",
  "tokio",
@@ -6601,14 +6662,14 @@ dependencies = [
  "base64 0.21.7",
  "bech32",
  "bitvec",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "cnidarium 0.83.0",
  "cnidarium-component 1.5.1",
  "decaf377",
  "decaf377-rdsa",
  "futures",
  "hex",
- "metrics 0.24.1",
+ "metrics 0.24.2",
  "once_cell",
  "pbjson-types 0.7.0",
  "penumbra-sdk-asset 1.5.1",
@@ -6623,12 +6684,12 @@ dependencies = [
  "penumbra-sdk-txhash 1.5.1",
  "prost 0.13.5",
  "prost-types 0.13.5",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
  "regex",
  "serde",
  "serde_with",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "tap",
  "tendermint 0.40.3",
  "tokio",
@@ -6653,14 +6714,14 @@ dependencies = [
  "base64 0.21.7",
  "bech32",
  "bitvec",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "cnidarium 0.83.0",
  "cnidarium-component 2.0.0-alpha.10",
  "decaf377",
  "decaf377-rdsa",
  "futures",
  "hex",
- "metrics 0.24.1",
+ "metrics 0.24.2",
  "once_cell",
  "pbjson-types 0.7.0",
  "penumbra-sdk-asset 2.0.0-alpha.10",
@@ -6675,12 +6736,12 @@ dependencies = [
  "penumbra-sdk-txhash 2.0.0-alpha.10",
  "prost 0.13.5",
  "prost-types 0.13.5",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
  "regex",
  "serde",
  "serde_with",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "tap",
  "tendermint 0.40.3",
  "tokio",
@@ -6697,12 +6758,12 @@ dependencies = [
  "ark-ff",
  "async-trait",
  "base64 0.21.7",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "cnidarium 0.83.0",
  "cnidarium-component 1.3.2",
  "futures",
  "hex",
- "metrics 0.24.1",
+ "metrics 0.24.2",
  "once_cell",
  "pbjson-types 0.7.0",
  "penumbra-sdk-asset 1.3.2",
@@ -6714,7 +6775,7 @@ dependencies = [
  "penumbra-sdk-txhash 1.3.2",
  "prost 0.13.5",
  "serde",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "tendermint 0.40.3",
  "tendermint-light-client-verifier 0.40.3",
  "tracing",
@@ -6729,12 +6790,12 @@ dependencies = [
  "ark-ff",
  "async-trait",
  "base64 0.21.7",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "cnidarium 0.83.0",
  "cnidarium-component 1.5.1",
  "futures",
  "hex",
- "metrics 0.24.1",
+ "metrics 0.24.2",
  "once_cell",
  "pbjson-types 0.7.0",
  "penumbra-sdk-asset 1.5.1",
@@ -6746,7 +6807,7 @@ dependencies = [
  "penumbra-sdk-txhash 1.5.1",
  "prost 0.13.5",
  "serde",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "tendermint 0.40.3",
  "tendermint-light-client-verifier 0.40.3",
  "tracing",
@@ -6761,12 +6822,12 @@ dependencies = [
  "ark-ff",
  "async-trait",
  "base64 0.21.7",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "cnidarium 0.83.0",
  "cnidarium-component 2.0.0-alpha.10",
  "futures",
  "hex",
- "metrics 0.24.1",
+ "metrics 0.24.2",
  "once_cell",
  "pbjson-types 0.7.0",
  "penumbra-sdk-asset 2.0.0-alpha.10",
@@ -6778,7 +6839,7 @@ dependencies = [
  "penumbra-sdk-txhash 2.0.0-alpha.10",
  "prost 0.13.5",
  "serde",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "tendermint 0.40.3",
  "tendermint-light-client-verifier 0.40.3",
  "tracing",
@@ -6792,14 +6853,14 @@ dependencies = [
  "anyhow",
  "ark-ff",
  "async-trait",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "bytes",
  "cnidarium 0.83.0",
  "cnidarium-component 1.3.2",
  "decaf377-rdsa",
  "futures",
  "im",
- "metrics 0.24.1",
+ "metrics 0.24.2",
  "penumbra-sdk-dex 1.3.2",
  "penumbra-sdk-fee 1.3.2",
  "penumbra-sdk-governance 1.3.2",
@@ -6810,8 +6871,8 @@ dependencies = [
  "penumbra-sdk-shielded-pool 1.3.2",
  "penumbra-sdk-stake 1.3.2",
  "penumbra-sdk-tct 1.3.2",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "serde",
  "tendermint 0.40.3",
  "tokio",
@@ -6828,14 +6889,14 @@ dependencies = [
  "anyhow",
  "ark-ff",
  "async-trait",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "bytes",
  "cnidarium 0.83.0",
  "cnidarium-component 1.5.1",
  "decaf377-rdsa",
  "futures",
  "im",
- "metrics 0.24.1",
+ "metrics 0.24.2",
  "penumbra-sdk-dex 1.5.1",
  "penumbra-sdk-fee 1.5.1",
  "penumbra-sdk-governance 1.5.1",
@@ -6846,8 +6907,8 @@ dependencies = [
  "penumbra-sdk-shielded-pool 1.5.1",
  "penumbra-sdk-stake 1.5.1",
  "penumbra-sdk-tct 1.5.1",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "serde",
  "tendermint 0.40.3",
  "tokio",
@@ -6864,14 +6925,14 @@ dependencies = [
  "anyhow",
  "ark-ff",
  "async-trait",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "bytes",
  "cnidarium 0.83.0",
  "cnidarium-component 2.0.0-alpha.10",
  "decaf377-rdsa",
  "futures",
  "im",
- "metrics 0.24.1",
+ "metrics 0.24.2",
  "penumbra-sdk-dex 2.0.0-alpha.10",
  "penumbra-sdk-fee 2.0.0-alpha.10",
  "penumbra-sdk-governance 2.0.0-alpha.10",
@@ -6882,8 +6943,8 @@ dependencies = [
  "penumbra-sdk-shielded-pool 2.0.0-alpha.10",
  "penumbra-sdk-stake 2.0.0-alpha.10",
  "penumbra-sdk-tct 2.0.0-alpha.10",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "serde",
  "tendermint 0.40.3",
  "tokio",
@@ -6908,7 +6969,7 @@ dependencies = [
  "async-trait",
  "base64 0.21.7",
  "bincode",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "cnidarium 0.83.0",
  "cnidarium-component 1.3.2",
  "decaf377",
@@ -6918,7 +6979,7 @@ dependencies = [
  "futures",
  "hex",
  "im",
- "metrics 0.24.1",
+ "metrics 0.24.2",
  "metrics-exporter-prometheus 0.16.2",
  "once_cell",
  "parking_lot",
@@ -6935,15 +6996,15 @@ dependencies = [
  "penumbra-sdk-txhash 1.3.2",
  "poseidon377",
  "prost 0.13.5",
- "rand_core",
+ "rand_core 0.6.4",
  "regex",
  "serde",
  "serde_json",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "tap",
  "tendermint 0.40.3",
  "tendermint-light-client-verifier 0.40.3",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
  "tonic 0.12.3",
@@ -6966,7 +7027,7 @@ dependencies = [
  "async-trait",
  "base64 0.21.7",
  "bincode",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "cnidarium 0.83.0",
  "cnidarium-component 1.5.1",
  "decaf377",
@@ -6976,7 +7037,7 @@ dependencies = [
  "futures",
  "hex",
  "im",
- "metrics 0.24.1",
+ "metrics 0.24.2",
  "metrics-exporter-prometheus 0.16.2",
  "once_cell",
  "parking_lot",
@@ -6993,15 +7054,15 @@ dependencies = [
  "penumbra-sdk-txhash 1.5.1",
  "poseidon377",
  "prost 0.13.5",
- "rand_core",
+ "rand_core 0.6.4",
  "regex",
  "serde",
  "serde_json",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "tap",
  "tendermint 0.40.3",
  "tendermint-light-client-verifier 0.40.3",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
  "tonic 0.12.3",
@@ -7024,7 +7085,7 @@ dependencies = [
  "async-trait",
  "base64 0.21.7",
  "bincode",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "cnidarium 0.83.0",
  "cnidarium-component 2.0.0-alpha.10",
  "decaf377",
@@ -7034,7 +7095,7 @@ dependencies = [
  "futures",
  "hex",
  "im",
- "metrics 0.24.1",
+ "metrics 0.24.2",
  "metrics-exporter-prometheus 0.16.2",
  "once_cell",
  "parking_lot",
@@ -7051,15 +7112,15 @@ dependencies = [
  "penumbra-sdk-txhash 2.0.0-alpha.10",
  "poseidon377",
  "prost 0.13.5",
- "rand_core",
+ "rand_core 0.6.4",
  "regex",
  "serde",
  "serde_json",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "tap",
  "tendermint 0.40.3",
  "tendermint-light-client-verifier 0.40.3",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
  "tonic 0.12.3",
@@ -7129,19 +7190,19 @@ dependencies = [
  "anyhow",
  "ark-ff",
  "async-trait",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "bytes",
  "cnidarium 0.83.0",
  "cnidarium-component 1.3.2",
  "decaf377",
  "decaf377-rdsa",
  "im",
- "metrics 0.24.1",
+ "metrics 0.24.2",
  "penumbra-sdk-asset 1.3.2",
  "penumbra-sdk-num 1.3.2",
  "penumbra-sdk-proto 1.3.2",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "serde",
  "tendermint 0.40.3",
  "tonic 0.12.3",
@@ -7156,19 +7217,19 @@ dependencies = [
  "anyhow",
  "ark-ff",
  "async-trait",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "bytes",
  "cnidarium 0.83.0",
  "cnidarium-component 1.5.1",
  "decaf377",
  "decaf377-rdsa",
  "im",
- "metrics 0.24.1",
+ "metrics 0.24.2",
  "penumbra-sdk-asset 1.5.1",
  "penumbra-sdk-num 1.5.1",
  "penumbra-sdk-proto 1.5.1",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "serde",
  "tendermint 0.40.3",
  "tonic 0.12.3",
@@ -7183,19 +7244,19 @@ dependencies = [
  "anyhow",
  "ark-ff",
  "async-trait",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "bytes",
  "cnidarium 0.83.0",
  "cnidarium-component 2.0.0-alpha.10",
  "decaf377",
  "decaf377-rdsa",
  "im",
- "metrics 0.24.1",
+ "metrics 0.24.2",
  "penumbra-sdk-asset 2.0.0-alpha.10",
  "penumbra-sdk-num 2.0.0-alpha.10",
  "penumbra-sdk-proto 2.0.0-alpha.10",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "serde",
  "tendermint 0.40.3",
  "tonic 0.12.3",
@@ -7212,7 +7273,7 @@ dependencies = [
  "cnidarium 0.83.0",
  "cnidarium-component 1.3.2",
  "futures",
- "metrics 0.24.1",
+ "metrics 0.24.2",
  "penumbra-sdk-asset 1.3.2",
  "penumbra-sdk-community-pool 1.3.2",
  "penumbra-sdk-distributions 1.3.2",
@@ -7236,7 +7297,7 @@ dependencies = [
  "cnidarium 0.83.0",
  "cnidarium-component 1.5.1",
  "futures",
- "metrics 0.24.1",
+ "metrics 0.24.2",
  "penumbra-sdk-asset 1.5.1",
  "penumbra-sdk-community-pool 1.5.1",
  "penumbra-sdk-distributions 1.5.1",
@@ -7264,7 +7325,7 @@ dependencies = [
  "decaf377",
  "decaf377-rdsa",
  "futures",
- "metrics 0.24.1",
+ "metrics 0.24.2",
  "penumbra-sdk-asset 2.0.0-alpha.10",
  "penumbra-sdk-community-pool 2.0.0-alpha.10",
  "penumbra-sdk-dex 2.0.0-alpha.10",
@@ -7279,7 +7340,7 @@ dependencies = [
  "penumbra-sdk-stake 2.0.0-alpha.10",
  "penumbra-sdk-tct 2.0.0-alpha.10",
  "penumbra-sdk-txhash 2.0.0-alpha.10",
- "rand",
+ "rand 0.8.5",
  "serde",
  "tendermint 0.40.3",
  "tonic 0.12.3",
@@ -7301,7 +7362,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "base64 0.21.7",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "bytes",
  "cnidarium 0.83.0",
  "cnidarium-component 1.3.2",
@@ -7310,7 +7371,7 @@ dependencies = [
  "futures",
  "ibc-types 0.15.1",
  "im",
- "metrics 0.24.1",
+ "metrics 0.24.2",
  "once_cell",
  "pbjson-types 0.7.0",
  "penumbra-sdk-asset 1.3.2",
@@ -7325,15 +7386,15 @@ dependencies = [
  "penumbra-sdk-stake 1.3.2",
  "penumbra-sdk-tct 1.3.2",
  "penumbra-sdk-txhash 1.3.2",
- "rand",
- "rand_chacha",
- "rand_core",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
  "regex",
  "serde",
  "serde_json",
  "tap",
  "tendermint 0.40.3",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tonic 0.12.3",
  "tracing",
@@ -7354,7 +7415,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "base64 0.21.7",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "bytes",
  "cnidarium 0.83.0",
  "cnidarium-component 1.5.1",
@@ -7363,7 +7424,7 @@ dependencies = [
  "futures",
  "ibc-types 0.15.1",
  "im",
- "metrics 0.24.1",
+ "metrics 0.24.2",
  "once_cell",
  "pbjson-types 0.7.0",
  "penumbra-sdk-asset 1.5.1",
@@ -7378,15 +7439,15 @@ dependencies = [
  "penumbra-sdk-stake 1.5.1",
  "penumbra-sdk-tct 1.5.1",
  "penumbra-sdk-txhash 1.5.1",
- "rand",
- "rand_chacha",
- "rand_core",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
  "regex",
  "serde",
  "serde_json",
  "tap",
  "tendermint 0.40.3",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tonic 0.12.3",
  "tracing",
@@ -7407,7 +7468,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "base64 0.21.7",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "bytes",
  "cnidarium 0.83.0",
  "cnidarium-component 2.0.0-alpha.10",
@@ -7416,7 +7477,7 @@ dependencies = [
  "futures",
  "ibc-types 0.15.1",
  "im",
- "metrics 0.24.1",
+ "metrics 0.24.2",
  "once_cell",
  "pbjson-types 0.7.0",
  "penumbra-sdk-asset 2.0.0-alpha.10",
@@ -7431,15 +7492,15 @@ dependencies = [
  "penumbra-sdk-stake 2.0.0-alpha.10",
  "penumbra-sdk-tct 2.0.0-alpha.10",
  "penumbra-sdk-txhash 2.0.0-alpha.10",
- "rand",
- "rand_chacha",
- "rand_core",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
  "regex",
  "serde",
  "serde_json",
  "tap",
  "tendermint 0.40.3",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tonic 0.12.3",
  "tracing",
@@ -7454,14 +7515,14 @@ dependencies = [
  "ark-ff",
  "async-trait",
  "base64 0.21.7",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "cnidarium 0.83.0",
  "futures",
  "hex",
  "ibc-proto 0.51.1",
  "ibc-types 0.15.1",
  "ics23 0.12.0",
- "metrics 0.24.1",
+ "metrics 0.24.2",
  "num-traits",
  "once_cell",
  "pbjson-types 0.7.0",
@@ -7473,7 +7534,7 @@ dependencies = [
  "prost 0.13.5",
  "serde",
  "serde_json",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "tendermint 0.40.3",
  "tendermint-light-client-verifier 0.40.3",
  "time",
@@ -7491,14 +7552,14 @@ dependencies = [
  "ark-ff",
  "async-trait",
  "base64 0.21.7",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "cnidarium 0.83.0",
  "futures",
  "hex",
  "ibc-proto 0.51.1",
  "ibc-types 0.15.1",
  "ics23 0.12.0",
- "metrics 0.24.1",
+ "metrics 0.24.2",
  "num-traits",
  "once_cell",
  "pbjson-types 0.7.0",
@@ -7510,7 +7571,7 @@ dependencies = [
  "prost 0.13.5",
  "serde",
  "serde_json",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "tendermint 0.40.3",
  "tendermint-light-client-verifier 0.40.3",
  "time",
@@ -7528,14 +7589,14 @@ dependencies = [
  "ark-ff",
  "async-trait",
  "base64 0.21.7",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "cnidarium 0.83.0",
  "futures",
  "hex",
  "ibc-proto 0.51.1",
  "ibc-types 0.15.1",
  "ics23 0.12.0",
- "metrics 0.24.1",
+ "metrics 0.24.2",
  "num-traits",
  "once_cell",
  "pbjson-types 0.7.0",
@@ -7547,7 +7608,7 @@ dependencies = [
  "prost 0.13.5",
  "serde",
  "serde_json",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "tendermint 0.40.3",
  "tendermint-light-client-verifier 0.40.3",
  "time",
@@ -7571,7 +7632,7 @@ dependencies = [
  "base64 0.21.7",
  "bech32",
  "bip32",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "bytes",
  "chacha20poly1305",
  "decaf377",
@@ -7591,12 +7652,12 @@ dependencies = [
  "penumbra-sdk-proto 1.3.2",
  "penumbra-sdk-tct 1.3.2",
  "poseidon377",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "regex",
  "serde",
- "sha2 0.10.8",
- "thiserror",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
  "tracing",
 ]
 
@@ -7615,7 +7676,7 @@ dependencies = [
  "base64 0.21.7",
  "bech32",
  "bip32",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "bytes",
  "chacha20poly1305",
  "decaf377",
@@ -7635,12 +7696,12 @@ dependencies = [
  "penumbra-sdk-proto 1.5.1",
  "penumbra-sdk-tct 1.5.1",
  "poseidon377",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "regex",
  "serde",
- "sha2 0.10.8",
- "thiserror",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
  "tracing",
 ]
 
@@ -7659,7 +7720,7 @@ dependencies = [
  "base64 0.21.7",
  "bech32",
  "bip32",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "bytes",
  "chacha20poly1305",
  "decaf377",
@@ -7679,12 +7740,12 @@ dependencies = [
  "penumbra-sdk-proto 2.0.0-alpha.10",
  "penumbra-sdk-tct 2.0.0-alpha.10",
  "poseidon377",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "regex",
  "serde",
- "sha2 0.10.8",
- "thiserror",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
  "tracing",
 ]
 
@@ -7703,7 +7764,7 @@ dependencies = [
  "ark-std",
  "base64 0.21.7",
  "bech32",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "bytes",
  "decaf377",
  "decaf377-fmd 1.3.2",
@@ -7715,12 +7776,12 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "penumbra-sdk-proto 1.3.2",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "regex",
  "serde",
- "sha2 0.10.8",
- "thiserror",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
  "tracing",
 ]
 
@@ -7739,7 +7800,7 @@ dependencies = [
  "ark-std",
  "base64 0.21.7",
  "bech32",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "bytes",
  "decaf377",
  "decaf377-fmd 1.5.1",
@@ -7751,12 +7812,12 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "penumbra-sdk-proto 1.5.1",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "regex",
  "serde",
- "sha2 0.10.8",
- "thiserror",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
  "tracing",
 ]
 
@@ -7775,7 +7836,7 @@ dependencies = [
  "ark-std",
  "base64 0.21.7",
  "bech32",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "bytes",
  "decaf377",
  "decaf377-fmd 2.0.0-alpha.10",
@@ -7787,12 +7848,12 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "penumbra-sdk-proto 2.0.0-alpha.10",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "regex",
  "serde",
- "sha2 0.10.8",
- "thiserror",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
  "tracing",
 ]
 
@@ -7814,10 +7875,10 @@ dependencies = [
  "decaf377",
  "num-bigint",
  "once_cell",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "serde",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "tracing",
 ]
 
@@ -7839,10 +7900,10 @@ dependencies = [
  "decaf377",
  "num-bigint",
  "once_cell",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "serde",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "tracing",
 ]
 
@@ -7864,10 +7925,10 @@ dependencies = [
  "decaf377",
  "num-bigint",
  "once_cell",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "serde",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "tracing",
 ]
 
@@ -7970,7 +8031,7 @@ dependencies = [
  "ark-serialize",
  "async-trait",
  "bincode",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "bytes",
  "chrono",
  "cnidarium 0.83.0",
@@ -7979,15 +8040,15 @@ dependencies = [
  "decaf377-rdsa",
  "hex",
  "im",
- "metrics 0.24.1",
+ "metrics 0.24.2",
  "once_cell",
  "pbjson-types 0.7.0",
  "penumbra-sdk-keys 1.3.2",
  "penumbra-sdk-proto 1.3.2",
  "penumbra-sdk-tct 1.3.2",
  "poseidon377",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "serde",
  "tendermint 0.40.3",
  "tonic 0.12.3",
@@ -8006,7 +8067,7 @@ dependencies = [
  "ark-serialize",
  "async-trait",
  "bincode",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "bytes",
  "chrono",
  "cnidarium 0.83.0",
@@ -8015,15 +8076,15 @@ dependencies = [
  "decaf377-rdsa",
  "hex",
  "im",
- "metrics 0.24.1",
+ "metrics 0.24.2",
  "once_cell",
  "pbjson-types 0.7.0",
  "penumbra-sdk-keys 1.5.1",
  "penumbra-sdk-proto 1.5.1",
  "penumbra-sdk-tct 1.5.1",
  "poseidon377",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "serde",
  "tendermint 0.40.3",
  "tonic 0.12.3",
@@ -8042,7 +8103,7 @@ dependencies = [
  "ark-serialize",
  "async-trait",
  "bincode",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "bytes",
  "chrono",
  "cnidarium 0.83.0",
@@ -8051,7 +8112,7 @@ dependencies = [
  "decaf377-rdsa",
  "hex",
  "im",
- "metrics 0.24.1",
+ "metrics 0.24.2",
  "once_cell",
  "pbjson-types 0.7.0",
  "penumbra-sdk-keys 2.0.0-alpha.10",
@@ -8059,8 +8120,8 @@ dependencies = [
  "penumbra-sdk-tct 2.0.0-alpha.10",
  "penumbra-sdk-txhash 2.0.0-alpha.10",
  "poseidon377",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "serde",
  "tendermint 0.40.3",
  "tonic 0.12.3",
@@ -8082,7 +8143,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "base64 0.21.7",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "bytes",
  "chacha20poly1305",
  "cnidarium 0.83.0",
@@ -8096,7 +8157,7 @@ dependencies = [
  "ibc-proto 0.51.1",
  "ibc-types 0.15.1",
  "im",
- "metrics 0.24.1",
+ "metrics 0.24.2",
  "once_cell",
  "penumbra-sdk-asset 1.3.2",
  "penumbra-sdk-ibc 1.3.2",
@@ -8109,14 +8170,14 @@ dependencies = [
  "penumbra-sdk-txhash 1.3.2",
  "poseidon377",
  "prost 0.13.5",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "regex",
  "serde",
  "serde_json",
  "tap",
  "tendermint 0.40.3",
- "thiserror",
+ "thiserror 1.0.69",
  "tonic 0.12.3",
  "tracing",
 ]
@@ -8136,7 +8197,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "base64 0.21.7",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "bytes",
  "chacha20poly1305",
  "cnidarium 0.83.0",
@@ -8150,7 +8211,7 @@ dependencies = [
  "ibc-proto 0.51.1",
  "ibc-types 0.15.1",
  "im",
- "metrics 0.24.1",
+ "metrics 0.24.2",
  "once_cell",
  "penumbra-sdk-asset 1.5.1",
  "penumbra-sdk-ibc 1.5.1",
@@ -8163,14 +8224,14 @@ dependencies = [
  "penumbra-sdk-txhash 1.5.1",
  "poseidon377",
  "prost 0.13.5",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "regex",
  "serde",
  "serde_json",
  "tap",
  "tendermint 0.40.3",
- "thiserror",
+ "thiserror 1.0.69",
  "tonic 0.12.3",
  "tracing",
 ]
@@ -8190,7 +8251,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "base64 0.21.7",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "bytes",
  "chacha20poly1305",
  "cnidarium 0.83.0",
@@ -8204,7 +8265,7 @@ dependencies = [
  "ibc-proto 0.51.1",
  "ibc-types 0.15.1",
  "im",
- "metrics 0.24.1",
+ "metrics 0.24.2",
  "once_cell",
  "penumbra-sdk-asset 2.0.0-alpha.10",
  "penumbra-sdk-ibc 2.0.0-alpha.10",
@@ -8217,14 +8278,14 @@ dependencies = [
  "penumbra-sdk-txhash 2.0.0-alpha.10",
  "poseidon377",
  "prost 0.13.5",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "regex",
  "serde",
  "serde_json",
  "tap",
  "tendermint 0.40.3",
- "thiserror",
+ "thiserror 1.0.69",
  "tonic 0.12.3",
  "tracing",
 ]
@@ -8253,7 +8314,7 @@ dependencies = [
  "futures",
  "hex",
  "im",
- "metrics 0.24.1",
+ "metrics 0.24.2",
  "once_cell",
  "penumbra-sdk-asset 1.3.2",
  "penumbra-sdk-distributions 1.3.2",
@@ -8265,13 +8326,13 @@ dependencies = [
  "penumbra-sdk-shielded-pool 1.3.2",
  "penumbra-sdk-tct 1.3.2",
  "penumbra-sdk-txhash 1.3.2",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
  "regex",
  "serde",
  "serde_unit_struct",
  "serde_with",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "tap",
  "tendermint 0.40.3",
  "tokio",
@@ -8303,7 +8364,7 @@ dependencies = [
  "futures",
  "hex",
  "im",
- "metrics 0.24.1",
+ "metrics 0.24.2",
  "once_cell",
  "penumbra-sdk-asset 1.5.1",
  "penumbra-sdk-distributions 1.5.1",
@@ -8315,13 +8376,13 @@ dependencies = [
  "penumbra-sdk-shielded-pool 1.5.1",
  "penumbra-sdk-tct 1.5.1",
  "penumbra-sdk-txhash 1.5.1",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
  "regex",
  "serde",
  "serde_unit_struct",
  "serde_with",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "tap",
  "tendermint 0.40.3",
  "tokio",
@@ -8353,7 +8414,7 @@ dependencies = [
  "futures",
  "hex",
  "im",
- "metrics 0.24.1",
+ "metrics 0.24.2",
  "once_cell",
  "penumbra-sdk-asset 2.0.0-alpha.10",
  "penumbra-sdk-distributions 2.0.0-alpha.10",
@@ -8365,13 +8426,13 @@ dependencies = [
  "penumbra-sdk-shielded-pool 2.0.0-alpha.10",
  "penumbra-sdk-tct 2.0.0-alpha.10",
  "penumbra-sdk-txhash 2.0.0-alpha.10",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
  "regex",
  "serde",
  "serde_unit_struct",
  "serde_with",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "tap",
  "tendermint 0.40.3",
  "tokio",
@@ -8390,11 +8451,11 @@ dependencies = [
  "ark-relations",
  "ark-serialize",
  "async-trait",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "decaf377",
  "derivative",
  "futures",
- "getrandom",
+ "getrandom 0.2.16",
  "hash_hasher",
  "hex",
  "im",
@@ -8402,9 +8463,9 @@ dependencies = [
  "parking_lot",
  "penumbra-sdk-proto 1.3.2",
  "poseidon377",
- "rand",
+ "rand 0.8.5",
  "serde",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
 ]
 
@@ -8419,11 +8480,11 @@ dependencies = [
  "ark-relations",
  "ark-serialize",
  "async-trait",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "decaf377",
  "derivative",
  "futures",
- "getrandom",
+ "getrandom 0.2.16",
  "hash_hasher",
  "hex",
  "im",
@@ -8431,9 +8492,9 @@ dependencies = [
  "parking_lot",
  "penumbra-sdk-proto 1.5.1",
  "poseidon377",
- "rand",
+ "rand 0.8.5",
  "serde",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
 ]
 
@@ -8448,11 +8509,11 @@ dependencies = [
  "ark-relations",
  "ark-serialize",
  "async-trait",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "decaf377",
  "derivative",
  "futures",
- "getrandom",
+ "getrandom 0.2.16",
  "hash_hasher",
  "hex",
  "im",
@@ -8460,9 +8521,9 @@ dependencies = [
  "parking_lot",
  "penumbra-sdk-proto 2.0.0-alpha.10",
  "poseidon377",
- "rand",
+ "rand 0.8.5",
  "serde",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
 ]
 
@@ -8473,15 +8534,15 @@ source = "git+https://github.com/penumbra-zone/penumbra?tag=v1.3.2#b5e0723a0a9ca
 dependencies = [
  "futures",
  "hex",
- "http 1.2.0",
+ "http 1.3.1",
  "pin-project",
  "pin-project-lite",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "tendermint 0.40.3",
  "tendermint-proto 0.40.3",
  "tokio",
  "tokio-stream",
- "tokio-util 0.7.11",
+ "tokio-util 0.7.15",
  "tonic 0.12.3",
  "tower 0.4.13",
  "tower-service",
@@ -8495,15 +8556,15 @@ source = "git+https://github.com/penumbra-zone/penumbra?tag=v1.5.1#d55e7e80eb42e
 dependencies = [
  "futures",
  "hex",
- "http 1.2.0",
+ "http 1.3.1",
  "pin-project",
  "pin-project-lite",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "tendermint 0.40.3",
  "tendermint-proto 0.40.3",
  "tokio",
  "tokio-stream",
- "tokio-util 0.7.11",
+ "tokio-util 0.7.15",
  "tonic 0.12.3",
  "tower 0.4.13",
  "tower-service",
@@ -8517,15 +8578,15 @@ source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.10#c209
 dependencies = [
  "futures",
  "hex",
- "http 1.2.0",
+ "http 1.3.1",
  "pin-project",
  "pin-project-lite",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "tendermint 0.40.3",
  "tendermint-proto 0.40.3",
  "tokio",
  "tokio-stream",
- "tokio-util 0.7.11",
+ "tokio-util 0.7.15",
  "tonic 0.12.3",
  "tower 0.4.13",
  "tower-service",
@@ -8542,7 +8603,7 @@ dependencies = [
  "ark-serialize",
  "base64 0.21.7",
  "bech32",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "bytes",
  "chacha20poly1305",
  "decaf377",
@@ -8573,13 +8634,13 @@ dependencies = [
  "penumbra-sdk-tct 1.3.2",
  "penumbra-sdk-txhash 1.3.2",
  "poseidon377",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "regex",
  "serde",
  "serde_json",
- "sha2 0.10.8",
- "thiserror",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
 ]
@@ -8594,7 +8655,7 @@ dependencies = [
  "ark-serialize",
  "base64 0.21.7",
  "bech32",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "bytes",
  "chacha20poly1305",
  "decaf377",
@@ -8625,13 +8686,13 @@ dependencies = [
  "penumbra-sdk-tct 1.5.1",
  "penumbra-sdk-txhash 1.5.1",
  "poseidon377",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "regex",
  "serde",
  "serde_json",
- "sha2 0.10.8",
- "thiserror",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
 ]
@@ -8646,7 +8707,7 @@ dependencies = [
  "ark-serialize",
  "base64 0.21.7",
  "bech32",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "bytes",
  "chacha20poly1305",
  "decaf377",
@@ -8678,13 +8739,13 @@ dependencies = [
  "penumbra-sdk-tct 2.0.0-alpha.10",
  "penumbra-sdk-txhash 2.0.0-alpha.10",
  "poseidon377",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "regex",
  "serde",
  "serde_json",
- "sha2 0.10.8",
- "thiserror",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
 ]
@@ -8695,8 +8756,8 @@ version = "1.3.2"
 source = "git+https://github.com/penumbra-zone/penumbra?tag=v1.3.2#b5e0723a0a9cacac9277d6186901806b8913859c"
 dependencies = [
  "anyhow",
- "blake2b_simd 1.0.2",
- "getrandom",
+ "blake2b_simd 1.0.3",
+ "getrandom 0.2.16",
  "hex",
  "penumbra-sdk-proto 1.3.2",
  "penumbra-sdk-tct 1.3.2",
@@ -8709,8 +8770,8 @@ version = "1.5.1"
 source = "git+https://github.com/penumbra-zone/penumbra?tag=v1.5.1#d55e7e80eb42ecb205d88d270644c3e23e2cde36"
 dependencies = [
  "anyhow",
- "blake2b_simd 1.0.2",
- "getrandom",
+ "blake2b_simd 1.0.3",
+ "getrandom 0.2.16",
  "hex",
  "penumbra-sdk-proto 1.5.1",
  "penumbra-sdk-tct 1.5.1",
@@ -8723,8 +8784,8 @@ version = "2.0.0-alpha.10"
 source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.10#c209a52ea26efc5a2f02df0105405e93917fa5c4"
 dependencies = [
  "anyhow",
- "blake2b_simd 1.0.2",
- "getrandom",
+ "blake2b_simd 1.0.3",
+ "getrandom 0.2.16",
  "hex",
  "penumbra-sdk-proto 2.0.0-alpha.10",
  "penumbra-sdk-tct 2.0.0-alpha.10",
@@ -8746,7 +8807,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "base64 0.21.7",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "bytes",
  "chacha20poly1305",
  "cnidarium 0.79.7",
@@ -8760,7 +8821,7 @@ dependencies = [
  "ibc-proto 0.41.0",
  "ibc-types 0.12.1",
  "im",
- "metrics 0.22.3",
+ "metrics 0.22.4",
  "once_cell",
  "penumbra-asset 0.79.7",
  "penumbra-ibc 0.79.7",
@@ -8773,14 +8834,14 @@ dependencies = [
  "penumbra-txhash 0.79.7",
  "poseidon377",
  "prost 0.12.6",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "regex",
  "serde",
  "serde_json",
  "tap",
  "tendermint 0.34.1",
- "thiserror",
+ "thiserror 1.0.69",
  "tonic 0.10.2",
  "tracing",
 ]
@@ -8800,7 +8861,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "base64 0.21.7",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "bytes",
  "chacha20poly1305",
  "cnidarium 0.80.13",
@@ -8814,7 +8875,7 @@ dependencies = [
  "ibc-proto 0.41.0",
  "ibc-types 0.12.1",
  "im",
- "metrics 0.22.3",
+ "metrics 0.22.4",
  "once_cell",
  "penumbra-asset 0.80.13",
  "penumbra-ibc 0.80.13",
@@ -8827,14 +8888,14 @@ dependencies = [
  "penumbra-txhash 0.80.13",
  "poseidon377",
  "prost 0.12.6",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "regex",
  "serde",
  "serde_json",
  "tap",
  "tendermint 0.34.1",
- "thiserror",
+ "thiserror 1.0.69",
  "tonic 0.10.2",
  "tracing",
 ]
@@ -8854,7 +8915,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "base64 0.21.7",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "bytes",
  "chacha20poly1305",
  "cnidarium 0.81.3",
@@ -8868,7 +8929,7 @@ dependencies = [
  "ibc-proto 0.41.0",
  "ibc-types 0.12.1",
  "im",
- "metrics 0.22.3",
+ "metrics 0.22.4",
  "once_cell",
  "penumbra-asset 0.81.3",
  "penumbra-ibc 0.81.3",
@@ -8881,14 +8942,14 @@ dependencies = [
  "penumbra-txhash 0.81.3",
  "poseidon377",
  "prost 0.12.6",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "regex",
  "serde",
  "serde_json",
  "tap",
  "tendermint 0.34.1",
- "thiserror",
+ "thiserror 1.0.69",
  "tonic 0.10.2",
  "tracing",
 ]
@@ -8917,7 +8978,7 @@ dependencies = [
  "futures",
  "hex",
  "im",
- "metrics 0.22.3",
+ "metrics 0.22.4",
  "once_cell",
  "penumbra-asset 0.79.7",
  "penumbra-distributions 0.79.7",
@@ -8929,13 +8990,13 @@ dependencies = [
  "penumbra-shielded-pool 0.79.7",
  "penumbra-tct 0.79.7",
  "penumbra-txhash 0.79.7",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
  "regex",
  "serde",
  "serde_unit_struct",
  "serde_with",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "tap",
  "tendermint 0.34.1",
  "tokio",
@@ -8967,7 +9028,7 @@ dependencies = [
  "futures",
  "hex",
  "im",
- "metrics 0.22.3",
+ "metrics 0.22.4",
  "once_cell",
  "penumbra-asset 0.80.13",
  "penumbra-distributions 0.80.13",
@@ -8979,13 +9040,13 @@ dependencies = [
  "penumbra-shielded-pool 0.80.13",
  "penumbra-tct 0.80.13",
  "penumbra-txhash 0.80.13",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
  "regex",
  "serde",
  "serde_unit_struct",
  "serde_with",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "tap",
  "tendermint 0.34.1",
  "tokio",
@@ -9017,7 +9078,7 @@ dependencies = [
  "futures",
  "hex",
  "im",
- "metrics 0.22.3",
+ "metrics 0.22.4",
  "once_cell",
  "penumbra-asset 0.81.3",
  "penumbra-distributions 0.81.3",
@@ -9029,13 +9090,13 @@ dependencies = [
  "penumbra-shielded-pool 0.81.3",
  "penumbra-tct 0.81.3",
  "penumbra-txhash 0.81.3",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
  "regex",
  "serde",
  "serde_unit_struct",
  "serde_with",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "tap",
  "tendermint 0.34.1",
  "tokio",
@@ -9054,7 +9115,7 @@ dependencies = [
  "ark-relations",
  "ark-serialize",
  "async-trait",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "decaf377",
  "derivative",
  "futures",
@@ -9065,9 +9126,9 @@ dependencies = [
  "parking_lot",
  "penumbra-proto 0.79.7",
  "poseidon377",
- "rand",
+ "rand 0.8.5",
  "serde",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
 ]
 
@@ -9082,11 +9143,11 @@ dependencies = [
  "ark-relations",
  "ark-serialize",
  "async-trait",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "decaf377",
  "derivative",
  "futures",
- "getrandom",
+ "getrandom 0.2.16",
  "hash_hasher",
  "hex",
  "im",
@@ -9094,9 +9155,9 @@ dependencies = [
  "parking_lot",
  "penumbra-proto 0.80.13",
  "poseidon377",
- "rand",
+ "rand 0.8.5",
  "serde",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
 ]
 
@@ -9111,11 +9172,11 @@ dependencies = [
  "ark-relations",
  "ark-serialize",
  "async-trait",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "decaf377",
  "derivative",
  "futures",
- "getrandom",
+ "getrandom 0.2.16",
  "hash_hasher",
  "hex",
  "im",
@@ -9123,9 +9184,9 @@ dependencies = [
  "parking_lot",
  "penumbra-proto 0.81.3",
  "poseidon377",
- "rand",
+ "rand 0.8.5",
  "serde",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
 ]
 
@@ -9139,13 +9200,13 @@ dependencies = [
  "futures",
  "hex",
  "http 0.2.12",
- "metrics 0.22.3",
+ "metrics 0.22.4",
  "pbjson-types 0.6.0",
  "penumbra-proto 0.79.7",
  "penumbra-transaction 0.79.7",
  "pin-project",
  "pin-project-lite",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "tap",
  "tendermint 0.34.1",
  "tendermint-config",
@@ -9154,7 +9215,7 @@ dependencies = [
  "tendermint-rpc",
  "tokio",
  "tokio-stream",
- "tokio-util 0.7.11",
+ "tokio-util 0.7.15",
  "tonic 0.10.2",
  "tower 0.4.13",
  "tower-service",
@@ -9168,7 +9229,7 @@ version = "0.79.7"
 source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.7#065c39855c38555a5315b55781dbb5645c87f5b7"
 dependencies = [
  "tracing",
- "tracing-subscriber 0.3.18",
+ "tracing-subscriber 0.3.19",
 ]
 
 [[package]]
@@ -9177,7 +9238,7 @@ version = "0.80.13"
 source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.80.13#a6cdc006c03568ed2f0472cd018b9a936dcf1c5d"
 dependencies = [
  "tracing",
- "tracing-subscriber 0.3.18",
+ "tracing-subscriber 0.3.19",
 ]
 
 [[package]]
@@ -9186,7 +9247,7 @@ version = "0.81.3"
 source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.81.3#8521a130b43aca39892a5ba27eb95eddc9a263ed"
 dependencies = [
  "tracing",
- "tracing-subscriber 0.3.18",
+ "tracing-subscriber 0.3.19",
 ]
 
 [[package]]
@@ -9199,12 +9260,12 @@ dependencies = [
  "http 0.2.12",
  "pin-project",
  "pin-project-lite",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "tendermint 0.34.1",
  "tendermint-proto 0.34.1",
  "tokio",
  "tokio-stream",
- "tokio-util 0.7.11",
+ "tokio-util 0.7.15",
  "tonic 0.10.2",
  "tower 0.4.13",
  "tower-service",
@@ -9221,12 +9282,12 @@ dependencies = [
  "http 0.2.12",
  "pin-project",
  "pin-project-lite",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "tendermint 0.34.1",
  "tendermint-proto 0.34.1",
  "tokio",
  "tokio-stream",
- "tokio-util 0.7.11",
+ "tokio-util 0.7.15",
  "tonic 0.10.2",
  "tower 0.4.13",
  "tower-service",
@@ -9243,12 +9304,12 @@ dependencies = [
  "http 0.2.12",
  "pin-project",
  "pin-project-lite",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "tendermint 0.34.1",
  "tendermint-proto 0.34.1",
  "tokio",
  "tokio-stream",
- "tokio-util 0.7.11",
+ "tokio-util 0.7.15",
  "tonic 0.10.2",
  "tower 0.4.13",
  "tower-service",
@@ -9265,7 +9326,7 @@ dependencies = [
  "ark-serialize",
  "base64 0.21.7",
  "bech32",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "bytes",
  "chacha20poly1305",
  "decaf377",
@@ -9296,13 +9357,13 @@ dependencies = [
  "penumbra-tct 0.79.7",
  "penumbra-txhash 0.79.7",
  "poseidon377",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "regex",
  "serde",
  "serde_json",
- "sha2 0.10.8",
- "thiserror",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
 ]
@@ -9317,7 +9378,7 @@ dependencies = [
  "ark-serialize",
  "base64 0.21.7",
  "bech32",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "bytes",
  "chacha20poly1305",
  "decaf377",
@@ -9348,13 +9409,13 @@ dependencies = [
  "penumbra-tct 0.80.13",
  "penumbra-txhash 0.80.13",
  "poseidon377",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "regex",
  "serde",
  "serde_json",
- "sha2 0.10.8",
- "thiserror",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
 ]
@@ -9369,7 +9430,7 @@ dependencies = [
  "ark-serialize",
  "base64 0.21.7",
  "bech32",
- "blake2b_simd 1.0.2",
+ "blake2b_simd 1.0.3",
  "bytes",
  "chacha20poly1305",
  "decaf377",
@@ -9400,13 +9461,13 @@ dependencies = [
  "penumbra-tct 0.81.3",
  "penumbra-txhash 0.81.3",
  "poseidon377",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "regex",
  "serde",
  "serde_json",
- "sha2 0.10.8",
- "thiserror",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
 ]
@@ -9417,8 +9478,8 @@ version = "0.79.7"
 source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.79.7#065c39855c38555a5315b55781dbb5645c87f5b7"
 dependencies = [
  "anyhow",
- "blake2b_simd 1.0.2",
- "getrandom",
+ "blake2b_simd 1.0.3",
+ "getrandom 0.2.16",
  "hex",
  "penumbra-proto 0.79.7",
  "penumbra-tct 0.79.7",
@@ -9431,8 +9492,8 @@ version = "0.80.13"
 source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.80.13#a6cdc006c03568ed2f0472cd018b9a936dcf1c5d"
 dependencies = [
  "anyhow",
- "blake2b_simd 1.0.2",
- "getrandom",
+ "blake2b_simd 1.0.3",
+ "getrandom 0.2.16",
  "hex",
  "penumbra-proto 0.80.13",
  "penumbra-tct 0.80.13",
@@ -9445,8 +9506,8 @@ version = "0.81.3"
 source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.81.3#8521a130b43aca39892a5ba27eb95eddc9a263ed"
 dependencies = [
  "anyhow",
- "blake2b_simd 1.0.2",
- "getrandom",
+ "blake2b_simd 1.0.3",
+ "getrandom 0.2.16",
  "hex",
  "penumbra-proto 0.81.3",
  "penumbra-tct 0.81.3",
@@ -9465,35 +9526,45 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
- "fixedbitset",
- "indexmap 2.7.1",
+ "fixedbitset 0.4.2",
+ "indexmap 2.9.0",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+dependencies = [
+ "fixedbitset 0.5.7",
+ "indexmap 2.9.0",
 ]
 
 [[package]]
 name = "pin-project"
-version = "1.1.5"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.5"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.95",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.14"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pin-utils"
@@ -9524,9 +9595,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.30"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "poly1305"
@@ -9541,9 +9612,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.7.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da544ee218f0d287a911e9c99a39a8c9bc8fcad3cb8db5959940044ecfc67265"
+checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
 
 [[package]]
 name = "poseidon-parameters"
@@ -9595,11 +9666,11 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.8.25",
 ]
 
 [[package]]
@@ -9631,12 +9702,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.20"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
+checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
 dependencies = [
- "proc-macro2 1.0.86",
- "syn 2.0.72",
+ "proc-macro2 1.0.95",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -9653,34 +9724,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.1.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
+checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
 dependencies = [
- "toml_edit 0.21.1",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2 1.0.86",
- "quote",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2 1.0.86",
- "quote",
- "version_check",
+ "toml_edit",
 ]
 
 [[package]]
@@ -9689,14 +9737,14 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "557facecbf90ff79faea80a08230d10c812016aa19198ed07d06de61f965b5cc"
 dependencies = [
- "unicode-xid",
+ "unicode-xid 0.1.0",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
@@ -9733,12 +9781,12 @@ dependencies = [
  "log",
  "multimap",
  "once_cell",
- "petgraph",
+ "petgraph 0.6.5",
  "prettyplease",
  "prost 0.12.6",
  "prost-types 0.12.6",
  "regex",
- "syn 2.0.72",
+ "syn 2.0.101",
  "tempfile",
 ]
 
@@ -9749,16 +9797,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
- "petgraph",
+ "petgraph 0.7.1",
  "prettyplease",
  "prost 0.13.5",
  "prost-types 0.13.5",
  "regex",
- "syn 2.0.72",
+ "syn 2.0.101",
  "tempfile",
 ]
 
@@ -9770,9 +9818,9 @@ checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
  "itertools 0.12.1",
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.95",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -9782,10 +9830,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
- "proc-macro2 1.0.86",
+ "itertools 0.14.0",
+ "proc-macro2 1.0.95",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -9808,27 +9856,33 @@ dependencies = [
 
 [[package]]
 name = "quanta"
-version = "0.12.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5167a477619228a0b284fac2674e3c388cba90631d7b7de620e6f1fcd08da5"
+checksum = "3bd1fe6824cea6538803de3ff1bc0cf3949024db3d43c9643024bfb33a807c0e"
 dependencies = [
  "crossbeam-utils",
  "libc",
  "once_cell",
  "raw-cpuid",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "web-sys",
  "winapi",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.95",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "radium"
@@ -9843,8 +9897,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -9854,7 +9918,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -9863,7 +9937,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.16",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.2",
 ]
 
 [[package]]
@@ -9872,16 +9955,25 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core 0.9.3",
 ]
 
 [[package]]
 name = "raw-cpuid"
-version = "11.1.0"
+version = "11.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb9ee317cfe3fbd54b36a511efc1edd42e216903c9cd575e686dd68a2ba90d8d"
+checksum = "c6df7ab838ed27997ba19a4664507e6f82b41fe6e20be42929332156e5e85146"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -9906,43 +9998,34 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.4.1"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
 dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
-dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
 name = "redox_users"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.16",
  "libredox",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "regex"
-version = "1.10.6"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.7",
- "regex-syntax 0.8.4",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -9956,13 +10039,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.4",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -9973,9 +10056,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
@@ -9991,7 +10074,7 @@ dependencies = [
  "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.30",
+ "hyper 0.14.32",
  "hyper-rustls 0.24.2",
  "ipnet",
  "js-sys",
@@ -10020,9 +10103,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.12"
+version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
+checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
 dependencies = [
  "async-compression",
  "base64 0.22.1",
@@ -10030,8 +10113,8 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.4.7",
- "http 1.2.0",
+ "h2 0.4.9",
+ "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.6.0",
@@ -10054,7 +10137,7 @@ dependencies = [
  "system-configuration 0.6.1",
  "tokio",
  "tokio-native-tls",
- "tokio-util 0.7.11",
+ "tokio-util 0.7.15",
  "tower 0.5.2",
  "tower-service",
  "url",
@@ -10077,15 +10160,14 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.8"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.16",
  "libc",
- "spin",
  "untrusted",
  "windows-sys 0.52.0",
 ]
@@ -10111,9 +10193,9 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.9.6"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0e5124fcb30e76a7e79bfee683a2746db83784b86289f6251b54b7950a0dfc"
+checksum = "78928ac1ed176a5ca1d17e578a1825f3d81ca54cf41053a592584b020cfd691b"
 dependencies = [
  "const-oid",
  "digest 0.10.7",
@@ -10122,7 +10204,7 @@ dependencies = [
  "num-traits",
  "pkcs1",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "signature",
  "spki",
  "subtle",
@@ -10142,6 +10224,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
 name = "rustc-hex"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10149,24 +10237,37 @@ checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustc_version"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
 ]
 
 [[package]]
 name = "rustix"
-version = "0.38.34"
+version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "errno",
  "libc",
- "linux-raw-sys",
- "windows-sys 0.52.0",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+dependencies = [
+ "bitflags 2.9.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.4",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10183,14 +10284,14 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.22"
+version = "0.23.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb9263ab4eb695e42321db096e3b8fbd715a59b154d5c88d82db2175b681ba7"
+checksum = "df51b5869f3a441595eac5e8ff14d486ff285f7b8c0df8770e49c3b56351f0f0"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
  "rustls-pki-types",
- "rustls-webpki 0.102.8",
+ "rustls-webpki 0.103.1",
  "subtle",
  "zeroize",
 ]
@@ -10255,9 +10356,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.8"
+version = "0.103.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+checksum = "fef8b8769aaccf73098557a87cd1816b4f9c7c16811c9c77142aa695c16f2c03"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -10267,30 +10368,30 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.17"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "safe-proc-macro2"
-version = "1.0.67"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fd85be67db87168aa3c13fd0da99f48f2ab005dccad5af5626138dc1df20eb6"
+checksum = "cdb2493004725bd1fdc167b7bd341125c4d0ffb45395d31741fa139d71b90525"
 dependencies = [
- "unicode-ident",
+ "unicode-xid 0.2.6",
 ]
 
 [[package]]
 name = "safe-quote"
-version = "1.0.15"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77e530f7831f3feafcd5f1aae406ac205dd998436b4007c8e80f03eca78a88f7"
+checksum = "571eb18c5e2ecd0a8221706807c30a1194b42fb15bd8bc589625706dc26ba722"
 dependencies = [
  "safe-proc-macro2",
 ]
@@ -10335,11 +10436,11 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.23"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
+checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10372,12 +10473,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "secp256k1"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
+dependencies = [
+ "secp256k1-sys",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70a129b9e9efbfb223753b9163c4ab3b13cff7fd9c7f010fbac25ab4099fa07e"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -10390,7 +10509,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "core-foundation 0.10.0",
  "core-foundation-sys",
  "libc",
@@ -10409,44 +10528,44 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.23"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "serde"
-version = "1.0.208"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff085d2cb684faa248efb494c39b68e522822ac0de72ccf08109abde717cfb2"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.15"
+version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "387cc504cb06bb40a96c8e04e951fe01854cf6bc921053c954e4a606d9675c6a"
+checksum = "8437fd221bde2d4ca316d61b90e337e9e702b3820b87d63caa9ba6c02bd06d96"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.208"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24008e81ff7613ed8e5ba0cfaf24e2c2f1e5b8a0495711e44fcd4882fca62bcf"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.95",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.125"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83c8e735a073ccf5be70aa8066aa984eaf2fa000db6c8d0100ae605b366d31ed"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",
@@ -10456,20 +10575,20 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.95",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
 dependencies = [
  "serde",
 ]
@@ -10490,7 +10609,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f1b15838534b38fb67ffe60033fe3ffad48f916c175e8baa0400e0cdb958dec"
 dependencies = [
  "quote",
- "syn 2.0.72",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -10507,15 +10626,15 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.9.0"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cecfa94848272156ea67b2b1a53f20fc7bc638c4a46d2f8abde08f05f4b857"
+checksum = "d6b6f7f2fcb69f747921f79f3926bd1e203fce4fef62c268dd3abfb6d86029aa"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.7.1",
+ "indexmap 2.9.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -10525,14 +10644,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.9.0"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8fee4991ef4f274617a51ad4af30519438dacb2f56ac773b08a1922ff743350"
+checksum = "8d00caa5193a3c8362ac2b73be6b9e768aa5a4b2f721d8f4b339600c3cb51f8e"
 dependencies = [
  "darling",
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.95",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -10561,9 +10680,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -10597,9 +10716,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.2"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
 dependencies = [
  "libc",
 ]
@@ -10611,7 +10730,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -10647,18 +10766,18 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "socket2"
-version = "0.5.7"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
+checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -10684,20 +10803,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "sqlformat"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f895e3734318cc55f1fe66258926c9b910c124d47520339efecbb6c59cec7c1f"
-dependencies = [
- "nom",
- "unicode_categories",
-]
-
-[[package]]
 name = "sqlx"
-version = "0.8.0"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27144619c6e5802f1380337a209d2ac1c431002dd74c6e60aebff3c506dc4f0c"
+checksum = "f3c3a85280daca669cfd3bcb68a337882a8bc57ec882f72c5d13a430613a738e"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -10708,37 +10817,32 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.8.0"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a999083c1af5b5d6c071d34a708a19ba3e02106ad82ef7bbd69f5e48266b613b"
+checksum = "f743f2a3cea30a58cd479013f75550e879009e3a02f616f18ca699335aa248c3"
 dependencies = [
- "atoi",
- "byteorder",
+ "base64 0.22.1",
  "bytes",
  "crc",
  "crossbeam-queue",
  "either",
  "event-listener",
- "futures-channel",
  "futures-core",
  "futures-intrusive",
  "futures-io",
  "futures-util",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.3",
  "hashlink",
- "hex",
- "indexmap 2.7.1",
+ "indexmap 2.9.0",
  "log",
  "memchr",
  "once_cell",
- "paste",
  "percent-encoding",
  "serde",
  "serde_json",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "smallvec",
- "sqlformat",
- "thiserror",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -10747,38 +10851,38 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros"
-version = "0.8.0"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23217eb7d86c584b8cbe0337b9eacf12ab76fe7673c513141ec42565698bb88"
+checksum = "7f4200e0fde19834956d4252347c12a083bdcb237d7a1a1446bffd8768417dce"
 dependencies = [
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.95",
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn 2.0.72",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "sqlx-macros-core"
-version = "0.8.0"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a099220ae541c5db479c6424bdf1b200987934033c2584f79a0e1693601e776"
+checksum = "882ceaa29cade31beca7129b6beeb05737f44f82dbe2a9806ecea5a7093d00b7"
 dependencies = [
  "dotenvy",
  "either",
  "heck 0.5.0",
  "hex",
  "once_cell",
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.95",
  "quote",
  "serde",
  "serde_json",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "sqlx-core",
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn 2.0.72",
+ "syn 2.0.101",
  "tempfile",
  "tokio",
  "url",
@@ -10786,13 +10890,13 @@ dependencies = [
 
 [[package]]
 name = "sqlx-mysql"
-version = "0.8.0"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5afe4c38a9b417b6a9a5eeffe7235d0a106716495536e7727d1c7f4b1ff3eba6"
+checksum = "0afdd3aa7a629683c2d750c2df343025545087081ab5942593a5288855b1b7a7"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "byteorder",
  "bytes",
  "crc",
@@ -10813,35 +10917,34 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand",
+ "rand 0.8.5",
  "rsa",
  "serde",
  "sha1",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 2.0.12",
  "tracing",
  "whoami",
 ]
 
 [[package]]
 name = "sqlx-postgres"
-version = "0.8.0"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1dbb157e65f10dbe01f729339c06d239120221c9ad9fa0ba8408c4cc18ecf21"
+checksum = "a0bedbe1bbb5e2615ef347a5e9d8cd7680fb63e77d9dafc0f29be15e53f1ebe6"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "byteorder",
  "crc",
  "dotenvy",
  "etcetera",
  "futures-channel",
  "futures-core",
- "futures-io",
  "futures-util",
  "hex",
  "hkdf",
@@ -10852,23 +10955,23 @@ dependencies = [
  "md-5",
  "memchr",
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_json",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 2.0.12",
  "tracing",
  "whoami",
 ]
 
 [[package]]
 name = "sqlx-sqlite"
-version = "0.8.0"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b2cdd83c008a622d94499c0006d8ee5f821f36c89b7d625c900e5dc30b5c5ee"
+checksum = "c26083e9a520e8eb87a06b12347679b142dc2ea29e6e409f805644a7a979a5bc"
 dependencies = [
  "atoi",
  "flume",
@@ -10883,6 +10986,7 @@ dependencies = [
  "serde",
  "serde_urlencoded",
  "sqlx-core",
+ "thiserror 2.0.12",
  "tracing",
  "url",
 ]
@@ -10943,32 +11047,20 @@ version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.95",
  "quote",
  "unicode-ident",
 ]
 
 [[package]]
 name = "syn"
-version = "2.0.72"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.95",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "syn_derive"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1329189c02ff984e9736652b1631330da25eaa6bc639089ed4915d25446cbe7b"
-dependencies = [
- "proc-macro-error",
- "proc-macro2 1.0.86",
- "quote",
- "syn 2.0.72",
 ]
 
 [[package]]
@@ -10988,13 +11080,13 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.95",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -11014,7 +11106,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "core-foundation 0.9.4",
  "system-configuration-sys 0.6.0",
 ]
@@ -11047,9 +11139,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.43"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c65998313f8e17d0d553d28f91a0df93e4dbbbf770279c7bc21ca0f09ea1a1f6"
+checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
 dependencies = [
  "filetime",
  "libc",
@@ -11058,14 +11150,14 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.12.0"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
+checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
 dependencies = [
- "cfg-if",
  "fastrand",
+ "getrandom 0.3.2",
  "once_cell",
- "rustix",
+ "rustix 1.0.7",
  "windows-sys 0.59.0",
 ]
 
@@ -11089,7 +11181,7 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "serde_repr",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "signature",
  "subtle",
  "subtle-encoding",
@@ -11117,7 +11209,7 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "serde_repr",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "signature",
  "subtle",
  "subtle-encoding",
@@ -11209,10 +11301,10 @@ dependencies = [
  "bytes",
  "flex-error",
  "futures",
- "getrandom",
+ "getrandom 0.2.16",
  "peg",
  "pin-project",
- "rand",
+ "rand 0.8.5",
  "reqwest 0.11.27",
  "semver",
  "serde",
@@ -11223,7 +11315,7 @@ dependencies = [
  "tendermint 0.34.1",
  "tendermint-config",
  "tendermint-proto 0.34.1",
- "thiserror",
+ "thiserror 1.0.69",
  "time",
  "tokio",
  "tracing",
@@ -11240,22 +11332,42 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
-version = "1.0.63"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.63"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.95",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+dependencies = [
+ "proc-macro2 1.0.95",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -11270,9 +11382,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.36"
+version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
 dependencies = [
  "deranged",
  "itoa",
@@ -11285,15 +11397,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
 
 [[package]]
 name = "time-macros"
-version = "0.2.18"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
 dependencies = [
  "num-conv",
  "time-core",
@@ -11311,9 +11423,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
+checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -11326,9 +11438,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.39.3"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babc99b9923bfa4804bd74722ff02c0381021eafa4db9949217e3be8e84fff5"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "bytes",
@@ -11355,13 +11467,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.95",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -11386,11 +11498,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
+checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
- "rustls 0.23.22",
+ "rustls 0.23.26",
  "tokio",
 ]
 
@@ -11421,9 +11533,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.11"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
+checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
 dependencies = [
  "bytes",
  "futures-core",
@@ -11443,48 +11555,44 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.19"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+checksum = "05ae329d1f08c4d17a59bed7ff5b5a769d062e64a62d34a3261b219e62cd5aae"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.20",
+ "toml_edit",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.21.1"
+version = "0.22.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
+checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
 dependencies = [
- "indexmap 2.7.1",
- "toml_datetime",
- "winnow 0.5.40",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
-dependencies = [
- "indexmap 2.7.1",
+ "indexmap 2.9.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.18",
+ "toml_write",
+ "winnow",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076"
 
 [[package]]
 name = "tonic"
@@ -11500,7 +11608,7 @@ dependencies = [
  "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.30",
+ "hyper 0.14.32",
  "hyper-timeout 0.4.1",
  "percent-encoding",
  "pin-project",
@@ -11524,8 +11632,8 @@ dependencies = [
  "axum 0.7.9",
  "base64 0.22.1",
  "bytes",
- "h2 0.4.7",
- "http 1.2.0",
+ "h2 0.4.9",
+ "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.6.0",
@@ -11579,7 +11687,7 @@ dependencies = [
  "bytes",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.30",
+ "hyper 0.14.32",
  "pin-project",
  "tokio-stream",
  "tonic 0.10.2",
@@ -11597,7 +11705,7 @@ checksum = "5299dd20801ad736dccb4a5ea0da7376e59cd98f213bf1c3d478cf53f4834b58"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
  "pin-project",
@@ -11621,10 +11729,10 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "slab",
  "tokio",
- "tokio-util 0.7.11",
+ "tokio-util 0.7.15",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -11691,9 +11799,9 @@ checksum = "b882e5e82ee7440a08335f4d5a2edd9f7678b2cba73eac4826b53c22fd76fdd3"
 dependencies = [
  "futures",
  "pin-project",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
- "tokio-util 0.7.11",
+ "tokio-util 0.7.15",
  "tower 0.4.13",
  "tracing",
 ]
@@ -11704,7 +11812,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "bytes",
  "futures-core",
  "futures-util",
@@ -11722,9 +11830,9 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "bytes",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
  "pin-project-lite",
@@ -11746,9 +11854,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -11758,20 +11866,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.95",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
  "valuable",
@@ -11799,9 +11907,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -11823,9 +11931,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "uint"
@@ -11841,30 +11949,30 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.15"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
+checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
 dependencies = [
  "tinyvec",
 ]
 
 [[package]]
 name = "unicode-properties"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ea75f83c0137a9b98608359a5f1af8144876eb67bcb1ce837368e906a9f524"
+checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
 
 [[package]]
 name = "unicode-xid"
@@ -11873,10 +11981,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 
 [[package]]
-name = "unicode_categories"
-version = "0.1.1"
+name = "unicode-xid"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "universal-hash"
@@ -11925,15 +12033,15 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.10.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
+checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
 
 [[package]]
 name = "valuable"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"
@@ -11982,6 +12090,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
 name = "wasite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11989,47 +12106,48 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.93"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.93"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.95",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.101",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.43"
+version = "0.4.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
 dependencies = [
  "cfg-if",
  "js-sys",
+ "once_cell",
  "wasm-bindgen",
  "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.93"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -12037,28 +12155,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.93"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.95",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.101",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.93"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e072d4e72f700fb3443d8fe94a39315df013eef1104903cdb0a2abd322bbecd"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -12069,9 +12190,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.70"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -12086,16 +12207,16 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix",
+ "rustix 0.38.44",
 ]
 
 [[package]]
 name = "whoami"
-version = "1.5.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44ab49fad634e88f55bf8f9bb3abd2f27d7204172a112c7c9987e01c1c94ea9"
+checksum = "6994d13118ab492c3c80c1f81928718159254c53c472bf9ce36f8dae4add02a7"
 dependencies = [
- "redox_syscall 0.4.1",
+ "redox_syscall",
  "wasite",
 ]
 
@@ -12132,41 +12253,81 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
-version = "0.52.0"
+version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings 0.4.0",
 ]
 
 [[package]]
-name = "windows-registry"
-version = "0.2.0"
+name = "windows-implement"
+version = "0.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2 1.0.95",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2 1.0.95",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+
+[[package]]
+name = "windows-registry"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
 dependencies = [
  "windows-result",
- "windows-strings",
- "windows-targets 0.52.6",
+ "windows-strings 0.3.1",
+ "windows-targets 0.53.0",
 ]
 
 [[package]]
 name = "windows-result"
-version = "0.2.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.1.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
 dependencies = [
- "windows-result",
- "windows-targets 0.52.6",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -12220,11 +12381,27 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -12240,6 +12417,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12250,6 +12433,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -12264,10 +12453,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -12282,6 +12483,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12292,6 +12499,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -12306,6 +12519,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12318,19 +12537,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "winnow"
-version = "0.5.40"
+name = "windows_x86_64_msvc"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
-dependencies = [
- "memchr",
-]
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.6.18"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
+checksum = "9e27d6ad3dac991091e4d35de9ba2d2d00647c5d0fc26c5496dee55984ae111b"
 dependencies = [
  "memchr",
 ]
@@ -12343,6 +12559,15 @@ checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -12368,13 +12593,12 @@ dependencies = [
 
 [[package]]
 name = "xattr"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e105d177a3871454f754b33bb0ee637ecaaac997446375fd3e5d43a2ed00c909"
+checksum = "0d65cbf2f12c15564212d48f4e3dfb87923d25d611f2aed18f4cb23f0413d89e"
 dependencies = [
  "libc",
- "linux-raw-sys",
- "rustix",
+ "rustix 1.0.7",
 ]
 
 [[package]]
@@ -12395,9 +12619,9 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.95",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.101",
  "synstructure",
 ]
 
@@ -12407,8 +12631,16 @@ version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
- "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+dependencies = [
+ "zerocopy-derive 0.8.25",
 ]
 
 [[package]]
@@ -12417,29 +12649,40 @@ version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.95",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+dependencies = [
+ "proc-macro2 1.0.95",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.95",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.101",
  "synstructure",
 ]
 
@@ -12458,9 +12701,9 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.95",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -12480,17 +12723,18 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.95",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.13+zstd.1.5.6"
+version = "2.0.15+zstd.1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
+checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
 dependencies = [
+ "bindgen 0.71.1",
  "cc",
  "pkg-config",
 ]


### PR DESCRIPTION
Updating crates.io index
Updating git repository `https://github.com/penumbra-zone/penumbra` Updating git repository `https://github.com/penumbra-zone/penumbra` Updating git repository `https://github.com/penumbra-zone/penumbra` Updating git repository `https://github.com/penumbra-zone/penumbra` Updating git repository `https://github.com/penumbra-zone/penumbra` Updating git repository `https://github.com/penumbra-zone/penumbra` Updating git repository `https://github.com/zcash/librustzcash`
 Locking 251 packages to latest compatible versions
Updating addr2line v0.22.0 -> v0.24.2
Removing adler v1.0.2
Updating allocator-api2 v0.2.18 -> v0.2.21
Updating anstream v0.6.15 -> v0.6.18
Updating anstyle v1.0.8 -> v1.0.10
Updating anstyle-parse v0.2.5 -> v0.2.6
Updating anstyle-query v1.1.1 -> v1.1.2
Updating anstyle-wincon v3.0.4 -> v3.0.7
Updating anyhow v1.0.86 -> v1.0.98
Updating arrayref v0.3.8 -> v0.3.9
Updating assert_cmd v2.0.16 -> v2.0.17
Updating async-compression v0.4.22 -> v0.4.23
Updating async-trait v0.1.81 -> v0.1.88
Updating autocfg v1.3.0 -> v1.4.0
Updating aws-lc-rs v1.12.4 -> v1.13.0
Updating aws-lc-sys v0.26.0 -> v0.28.2
Updating backtrace v0.3.73 -> v0.3.74
Updating base64ct v1.6.0 -> v1.7.3
  Adding bindgen v0.71.1
Updating bip32 v0.5.2 -> v0.5.3
Updating bitflags v2.6.0 -> v2.9.0
Updating blake2b_simd v1.0.2 -> v1.0.3
Updating blake3 v1.5.3 -> v1.8.2
Updating borsh v1.5.1 -> v1.5.7
Updating borsh-derive v1.5.1 -> v1.5.7
Updating bstr v1.11.3 -> v1.12.0
Updating bumpalo v3.16.0 -> v3.17.0
Updating byte-slice-cast v1.2.2 -> v1.2.3
Updating bytes v1.7.1 -> v1.10.1
Updating bzip2-sys v0.1.11+1.0.8 -> v0.1.13+1.0.8
Updating cc v1.1.13 -> v1.2.20
Updating chrono v0.4.38 -> v0.4.41
Updating clap v4.5.16 -> v4.5.37
Updating clap_builder v4.5.15 -> v4.5.37
Updating clap_derive v4.5.13 -> v4.5.32
Updating clap_lex v0.7.2 -> v0.7.4
Updating colorchoice v1.0.2 -> v1.0.3
  Adding const_format v0.2.34
  Adding const_format_proc_macros v0.2.34
Updating constant_time_eq v0.3.0 -> v0.3.1
Updating cpufeatures v0.2.13 -> v0.2.17
Updating crossbeam-deque v0.8.5 -> v0.8.6
Updating crossbeam-queue v0.3.11 -> v0.3.12
Updating crossbeam-utils v0.8.20 -> v0.8.21
Updating crunchy v0.2.2 -> v0.2.3
Updating darling v0.20.10 -> v0.20.11
Updating darling_core v0.20.10 -> v0.20.11
Updating darling_macro v0.20.10 -> v0.20.11
Updating der v0.7.9 -> v0.7.10
Updating deranged v0.3.11 -> v0.4.0
Updating derive_more v0.99.18 -> v0.99.20
Updating dyn-clone v1.0.17 -> v1.0.19
Updating either v1.13.0 -> v1.15.0
Updating encoding_rs v0.8.34 -> v0.8.35
Updating equivalent v1.0.1 -> v1.0.2
Updating errno v0.3.9 -> v0.3.11
Updating escargot v0.5.13 -> v0.5.14
Updating ethnum v1.5.0 -> v1.5.1
Updating event-listener v5.3.1 -> v5.4.0
Updating fastrand v2.1.0 -> v2.3.0
Updating ff v0.13.0 -> v0.13.1
  Adding fixedbitset v0.5.7
Updating flate2 v1.0.35 -> v1.1.1
Updating flume v0.11.0 -> v0.11.1
Updating foldhash v0.1.4 -> v0.1.5
Updating futures v0.3.30 -> v0.3.31
Updating futures-channel v0.3.30 -> v0.3.31
Updating futures-executor v0.3.30 -> v0.3.31
Updating futures-io v0.3.30 -> v0.3.31
Updating futures-macro v0.3.30 -> v0.3.31
Updating futures-sink v0.3.30 -> v0.3.31
Updating futures-task v0.3.30 -> v0.3.31
Updating futures-util v0.3.30 -> v0.3.31
Removing getrandom v0.2.15
  Adding getrandom v0.2.16
  Adding getrandom v0.3.2
Updating gimli v0.29.0 -> v0.31.1
Updating glob v0.3.1 -> v0.3.2
Updating h2 v0.4.7 -> v0.4.9
Updating hashbrown v0.15.2 -> v0.15.3
Updating hashlink v0.9.1 -> v0.10.0
Updating home v0.5.9 -> v0.5.11
Updating http v1.2.0 -> v1.3.1
Updating http-body-util v0.1.2 -> v0.1.3
Updating httparse v1.9.4 -> v1.10.1
Updating hyper v0.14.30 -> v0.14.32
Updating hyper-util v0.1.10 -> v0.1.11
Updating iana-time-zone v0.1.60 -> v0.1.63
Updating icu_locid_transform_data v1.5.0 -> v1.5.1 Updating icu_normalizer_data v1.5.0 -> v1.5.1
Updating icu_properties_data v1.5.0 -> v1.5.1
Updating impl-trait-for-tuples v0.2.2 -> v0.2.3
Updating indexmap v2.7.1 -> v2.9.0
Updating inout v0.1.3 -> v0.1.4
Updating ipnet v2.9.0 -> v2.11.0
  Adding itertools v0.14.0
Updating itoa v1.0.11 -> v1.0.15
Updating jobserver v0.1.32 -> v0.1.33
Updating js-sys v0.3.70 -> v0.3.77
Updating k256 v0.13.3 -> v0.13.4
Updating libc v0.2.156 -> v0.2.172
Updating libloading v0.8.5 -> v0.8.6
Updating libm v0.2.8 -> v0.2.13
Updating libsqlite3-sys v0.28.0 -> v0.30.1
Updating libz-sys v1.1.19 -> v1.1.22
Removing linux-raw-sys v0.4.14
  Adding linux-raw-sys v0.4.15
  Adding linux-raw-sys v0.9.4
Updating litemap v0.7.4 -> v0.7.5
Updating log v0.4.22 -> v0.4.27
Updating lz4-sys v1.10.0 -> v1.11.1+lz4-1.10.0
Removing metrics v0.22.3
Removing metrics v0.24.1
  Adding metrics v0.22.4
  Adding metrics v0.24.2
Updating metrics-util v0.19.0 -> v0.19.1
Removing miniz_oxide v0.7.4
Removing miniz_oxide v0.8.3
  Adding miniz_oxide v0.8.8
Updating mio v1.0.2 -> v1.0.3
Updating native-tls v0.2.12 -> v0.2.14
Updating object v0.36.3 -> v0.36.7
Updating once_cell v1.19.0 -> v1.21.3
Updating openssl v0.10.66 -> v0.10.72
Updating openssl-probe v0.1.5 -> v0.1.6
Updating openssl-sys v0.9.103 -> v0.9.108
Updating parity-scale-codec v3.6.12 -> v3.7.4
Updating parity-scale-codec-derive v3.6.12 -> v3.7.4 Updating parking v2.2.0 -> v2.2.1
Updating peg v0.8.4 -> v0.8.5
Updating peg-macros v0.8.4 -> v0.8.5
Updating peg-runtime v0.8.3 -> v0.8.5
  Adding petgraph v0.7.1
Updating pin-project v1.1.5 -> v1.1.10
Updating pin-project-internal v1.1.5 -> v1.1.10
Updating pin-project-lite v0.2.14 -> v0.2.16
Updating pkg-config v0.3.30 -> v0.3.32
Updating portable-atomic v1.7.0 -> v1.11.0
Updating ppv-lite86 v0.2.20 -> v0.2.21
Updating prettyplease v0.2.20 -> v0.2.32
Updating proc-macro-crate v3.1.0 -> v3.3.0
Removing proc-macro-error v1.0.4
Removing proc-macro-error-attr v1.0.4
Updating proc-macro2 v1.0.86 -> v1.0.95
Updating quanta v0.12.3 -> v0.12.5
Updating quote v1.0.36 -> v1.0.40
  Adding r-efi v5.2.0
  Adding rand v0.9.1
  Adding rand_chacha v0.9.0
  Adding rand_core v0.9.3
  Adding rand_xoshiro v0.7.0
Updating raw-cpuid v11.1.0 -> v11.5.0
Removing redox_syscall v0.4.1
Removing redox_syscall v0.5.3
  Adding redox_syscall v0.5.11
Updating redox_users v0.4.5 -> v0.4.6
Updating regex v1.10.6 -> v1.11.1
Updating regex-automata v0.4.7 -> v0.4.9
Updating regex-syntax v0.8.4 -> v0.8.5
Updating reqwest v0.12.12 -> v0.12.15
Updating ring v0.17.8 -> v0.17.14
Updating rsa v0.9.6 -> v0.9.8
  Adding rustc-hash v2.1.1
Updating rustc_version v0.4.0 -> v0.4.1
Removing rustix v0.38.34
  Adding rustix v0.38.44
  Adding rustix v1.0.7
Updating rustls v0.23.22 -> v0.23.26
Updating rustls-webpki v0.102.8 -> v0.103.1
Updating rustversion v1.0.17 -> v1.0.20
Updating ryu v1.0.18 -> v1.0.20
Updating safe-proc-macro2 v1.0.67 -> v1.0.94
Updating safe-quote v1.0.15 -> v1.0.39
Updating schannel v0.1.23 -> v0.1.27
  Adding secp256k1 v0.27.0
  Adding secp256k1-sys v0.8.1
Updating semver v1.0.23 -> v1.0.26
Updating serde v1.0.208 -> v1.0.219
Updating serde_bytes v0.11.15 -> v0.11.17
Updating serde_derive v1.0.208 -> v1.0.219
Updating serde_json v1.0.125 -> v1.0.140
Updating serde_repr v0.1.19 -> v0.1.20
Updating serde_spanned v0.6.7 -> v0.6.8
Updating serde_with v3.9.0 -> v3.12.0
Updating serde_with_macros v3.9.0 -> v3.12.0
Updating sha2 v0.10.8 -> v0.10.9
Updating signal-hook-registry v1.4.2 -> v1.4.5
Updating smallvec v1.13.2 -> v1.15.0
Updating socket2 v0.5.7 -> v0.5.9
Removing sqlformat v0.2.4
Updating sqlx v0.8.0 -> v0.8.5
Updating sqlx-core v0.8.0 -> v0.8.5
Updating sqlx-macros v0.8.0 -> v0.8.5
Updating sqlx-macros-core v0.8.0 -> v0.8.5
Updating sqlx-mysql v0.8.0 -> v0.8.5
Updating sqlx-postgres v0.8.0 -> v0.8.5
Updating sqlx-sqlite v0.8.0 -> v0.8.5
Updating syn v2.0.72 -> v2.0.101
Removing syn_derive v0.1.8
Updating synstructure v0.13.1 -> v0.13.2
Updating tar v0.4.43 -> v0.4.44
Updating tempfile v3.12.0 -> v3.19.1
Removing thiserror v1.0.63
  Adding thiserror v1.0.69
  Adding thiserror v2.0.12
Removing thiserror-impl v1.0.63
  Adding thiserror-impl v1.0.69
  Adding thiserror-impl v2.0.12
Updating time v0.3.36 -> v0.3.41
Updating time-core v0.1.2 -> v0.1.4
Updating time-macros v0.2.18 -> v0.2.22
Updating tinyvec v1.8.0 -> v1.9.0
Updating tokio v1.39.3 -> v1.44.2
Updating tokio-macros v2.4.0 -> v2.5.0
Updating tokio-rustls v0.26.1 -> v0.26.2
Updating tokio-util v0.7.11 -> v0.7.15
Updating toml v0.8.19 -> v0.8.22
Updating toml_datetime v0.6.8 -> v0.6.9
Removing toml_edit v0.21.1
Removing toml_edit v0.22.20
  Adding toml_edit v0.22.26
  Adding toml_write v0.1.1
Updating tracing v0.1.40 -> v0.1.41
Updating tracing-attributes v0.1.27 -> v0.1.28
Updating tracing-core v0.1.32 -> v0.1.33
Updating tracing-subscriber v0.3.18 -> v0.3.19
Updating typenum v1.17.0 -> v1.18.0
Updating unicode-bidi v0.3.15 -> v0.3.18
Updating unicode-ident v1.0.12 -> v1.0.18
Updating unicode-normalization v0.1.23 -> v0.1.24
Updating unicode-properties v0.1.2 -> v0.1.3
  Adding unicode-xid v0.2.6
Removing unicode_categories v0.1.1
Updating uuid v1.10.0 -> v1.16.0
Updating valuable v0.1.0 -> v0.1.1
  Adding wasi v0.14.2+wasi-0.2.4
Updating wasm-bindgen v0.2.93 -> v0.2.100
Updating wasm-bindgen-backend v0.2.93 -> v0.2.100
Updating wasm-bindgen-futures v0.4.43 -> v0.4.50
Updating wasm-bindgen-macro v0.2.93 -> v0.2.100
Updating wasm-bindgen-macro-support v0.2.93 -> v0.2.100 Updating wasm-bindgen-shared v0.2.93 -> v0.2.100
Updating wasm-streams v0.4.1 -> v0.4.2
Updating web-sys v0.3.70 -> v0.3.77
Updating whoami v1.5.1 -> v1.6.0
Updating windows-core v0.52.0 -> v0.61.0
  Adding windows-implement v0.60.0
  Adding windows-interface v0.59.1
  Adding windows-link v0.1.1
Updating windows-registry v0.2.0 -> v0.4.0
Updating windows-result v0.2.0 -> v0.3.2
Removing windows-strings v0.1.0
  Adding windows-strings v0.3.1
  Adding windows-strings v0.4.0
  Adding windows-targets v0.53.0
  Adding windows_aarch64_gnullvm v0.53.0
  Adding windows_aarch64_msvc v0.53.0
  Adding windows_i686_gnu v0.53.0
  Adding windows_i686_gnullvm v0.53.0
  Adding windows_i686_msvc v0.53.0
  Adding windows_x86_64_gnu v0.53.0
  Adding windows_x86_64_gnullvm v0.53.0
  Adding windows_x86_64_msvc v0.53.0
Removing winnow v0.5.40
Removing winnow v0.6.18
  Adding winnow v0.7.8
  Adding wit-bindgen-rt v0.39.0
Updating xattr v1.4.0 -> v1.5.0
  Adding zerocopy v0.8.25
  Adding zerocopy-derive v0.8.25
Updating zerofrom v0.1.5 -> v0.1.6
Updating zerofrom-derive v0.1.5 -> v0.1.6
  Updating zstd-sys v2.0.13+zstd.1.5.6 -> v2.0.15+zstd.1.5.7