### PR TITLE
chore: update penumbra deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1209,8 +1209,8 @@ dependencies = [
 
 [[package]]
 name = "cnidarium-component"
-version = "1.5.1"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v1.5.1#d55e7e80eb42ecb205d88d270644c3e23e2cde36"
+version = "1.5.2"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v1.5.2#07c4ba1381fa76b47878dc231f616ae441266976"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1221,8 +1221,8 @@ dependencies = [
 
 [[package]]
 name = "cnidarium-component"
-version = "2.0.0-alpha.10"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.10#c209a52ea26efc5a2f02df0105405e93917fa5c4"
+version = "2.0.0-alpha.11"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1550,8 +1550,8 @@ dependencies = [
 
 [[package]]
 name = "decaf377-fmd"
-version = "1.5.1"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v1.5.1#d55e7e80eb42ecb205d88d270644c3e23e2cde36"
+version = "1.5.2"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v1.5.2#07c4ba1381fa76b47878dc231f616ae441266976"
 dependencies = [
  "ark-ff",
  "ark-serialize",
@@ -1564,8 +1564,8 @@ dependencies = [
 
 [[package]]
 name = "decaf377-fmd"
-version = "2.0.0-alpha.10"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.10#c209a52ea26efc5a2f02df0105405e93917fa5c4"
+version = "2.0.0-alpha.11"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
 dependencies = [
  "ark-ff",
  "ark-serialize",
@@ -1634,8 +1634,8 @@ dependencies = [
 
 [[package]]
 name = "decaf377-ka"
-version = "1.5.1"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v1.5.1#d55e7e80eb42ecb205d88d270644c3e23e2cde36"
+version = "1.5.2"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v1.5.2#07c4ba1381fa76b47878dc231f616ae441266976"
 dependencies = [
  "ark-ff",
  "decaf377",
@@ -1648,8 +1648,8 @@ dependencies = [
 
 [[package]]
 name = "decaf377-ka"
-version = "2.0.0-alpha.10"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.10#c209a52ea26efc5a2f02df0105405e93917fa5c4"
+version = "2.0.0-alpha.11"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
 dependencies = [
  "ark-ff",
  "decaf377",
@@ -6111,20 +6111,20 @@ dependencies = [
  "penumbra-sct 0.80.13",
  "penumbra-sct 0.81.3",
  "penumbra-sdk-app 1.3.2",
- "penumbra-sdk-app 1.5.1",
- "penumbra-sdk-app 2.0.0-alpha.10",
+ "penumbra-sdk-app 1.5.2",
+ "penumbra-sdk-app 2.0.0-alpha.11",
  "penumbra-sdk-governance 1.3.2",
- "penumbra-sdk-governance 1.5.1",
- "penumbra-sdk-governance 2.0.0-alpha.10",
+ "penumbra-sdk-governance 1.5.2",
+ "penumbra-sdk-governance 2.0.0-alpha.11",
  "penumbra-sdk-ibc 1.3.2",
- "penumbra-sdk-ibc 1.5.1",
- "penumbra-sdk-ibc 2.0.0-alpha.10",
+ "penumbra-sdk-ibc 1.5.2",
+ "penumbra-sdk-ibc 2.0.0-alpha.11",
  "penumbra-sdk-sct 1.3.2",
- "penumbra-sdk-sct 1.5.1",
- "penumbra-sdk-sct 2.0.0-alpha.10",
+ "penumbra-sdk-sct 1.5.2",
+ "penumbra-sdk-sct 2.0.0-alpha.11",
  "penumbra-sdk-transaction 1.3.2",
- "penumbra-sdk-transaction 1.5.1",
- "penumbra-sdk-transaction 2.0.0-alpha.10",
+ "penumbra-sdk-transaction 1.5.2",
+ "penumbra-sdk-transaction 2.0.0-alpha.11",
  "penumbra-transaction 0.80.13",
  "penumbra-transaction 0.81.3",
  "prost 0.13.5",
@@ -6328,8 +6328,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-app"
-version = "1.5.1"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v1.5.1#d55e7e80eb42ecb205d88d270644c3e23e2cde36"
+version = "1.5.2"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v1.5.2#07c4ba1381fa76b47878dc231f616ae441266976"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -6341,7 +6341,7 @@ dependencies = [
  "blake2b_simd 1.0.3",
  "cfg-if",
  "cnidarium 0.83.0",
- "cnidarium-component 1.5.1",
+ "cnidarium-component 1.5.2",
  "decaf377",
  "decaf377-rdsa",
  "futures",
@@ -6354,27 +6354,27 @@ dependencies = [
  "metrics 0.24.2",
  "once_cell",
  "parking_lot",
- "penumbra-sdk-asset 1.5.1",
- "penumbra-sdk-auction 1.5.1",
- "penumbra-sdk-community-pool 1.5.1",
- "penumbra-sdk-compact-block 1.5.1",
- "penumbra-sdk-dex 1.5.1",
- "penumbra-sdk-distributions 1.5.1",
- "penumbra-sdk-fee 1.5.1",
- "penumbra-sdk-funding 1.5.1",
- "penumbra-sdk-governance 1.5.1",
- "penumbra-sdk-ibc 1.5.1",
- "penumbra-sdk-keys 1.5.1",
- "penumbra-sdk-num 1.5.1",
- "penumbra-sdk-proof-params 1.5.1",
- "penumbra-sdk-proto 1.5.1",
- "penumbra-sdk-sct 1.5.1",
- "penumbra-sdk-shielded-pool 1.5.1",
- "penumbra-sdk-stake 1.5.1",
- "penumbra-sdk-tct 1.5.1",
- "penumbra-sdk-tower-trace 1.5.1",
- "penumbra-sdk-transaction 1.5.1",
- "penumbra-sdk-txhash 1.5.1",
+ "penumbra-sdk-asset 1.5.2",
+ "penumbra-sdk-auction 1.5.2",
+ "penumbra-sdk-community-pool 1.5.2",
+ "penumbra-sdk-compact-block 1.5.2",
+ "penumbra-sdk-dex 1.5.2",
+ "penumbra-sdk-distributions 1.5.2",
+ "penumbra-sdk-fee 1.5.2",
+ "penumbra-sdk-funding 1.5.2",
+ "penumbra-sdk-governance 1.5.2",
+ "penumbra-sdk-ibc 1.5.2",
+ "penumbra-sdk-keys 1.5.2",
+ "penumbra-sdk-num 1.5.2",
+ "penumbra-sdk-proof-params 1.5.2",
+ "penumbra-sdk-proto 1.5.2",
+ "penumbra-sdk-sct 1.5.2",
+ "penumbra-sdk-shielded-pool 1.5.2",
+ "penumbra-sdk-stake 1.5.2",
+ "penumbra-sdk-tct 1.5.2",
+ "penumbra-sdk-tower-trace 1.5.2",
+ "penumbra-sdk-transaction 1.5.2",
+ "penumbra-sdk-txhash 1.5.2",
  "prost 0.13.5",
  "rand_chacha 0.3.1",
  "regex",
@@ -6402,8 +6402,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-app"
-version = "2.0.0-alpha.10"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.10#c209a52ea26efc5a2f02df0105405e93917fa5c4"
+version = "2.0.0-alpha.11"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -6415,7 +6415,7 @@ dependencies = [
  "blake2b_simd 1.0.3",
  "cfg-if",
  "cnidarium 0.83.0",
- "cnidarium-component 2.0.0-alpha.10",
+ "cnidarium-component 2.0.0-alpha.11",
  "decaf377",
  "decaf377-rdsa",
  "futures",
@@ -6428,27 +6428,27 @@ dependencies = [
  "metrics 0.24.2",
  "once_cell",
  "parking_lot",
- "penumbra-sdk-asset 2.0.0-alpha.10",
- "penumbra-sdk-auction 2.0.0-alpha.10",
- "penumbra-sdk-community-pool 2.0.0-alpha.10",
- "penumbra-sdk-compact-block 2.0.0-alpha.10",
- "penumbra-sdk-dex 2.0.0-alpha.10",
- "penumbra-sdk-distributions 2.0.0-alpha.10",
- "penumbra-sdk-fee 2.0.0-alpha.10",
- "penumbra-sdk-funding 2.0.0-alpha.10",
- "penumbra-sdk-governance 2.0.0-alpha.10",
- "penumbra-sdk-ibc 2.0.0-alpha.10",
- "penumbra-sdk-keys 2.0.0-alpha.10",
- "penumbra-sdk-num 2.0.0-alpha.10",
- "penumbra-sdk-proof-params 2.0.0-alpha.10",
- "penumbra-sdk-proto 2.0.0-alpha.10",
- "penumbra-sdk-sct 2.0.0-alpha.10",
- "penumbra-sdk-shielded-pool 2.0.0-alpha.10",
- "penumbra-sdk-stake 2.0.0-alpha.10",
- "penumbra-sdk-tct 2.0.0-alpha.10",
- "penumbra-sdk-tower-trace 2.0.0-alpha.10",
- "penumbra-sdk-transaction 2.0.0-alpha.10",
- "penumbra-sdk-txhash 2.0.0-alpha.10",
+ "penumbra-sdk-asset 2.0.0-alpha.11",
+ "penumbra-sdk-auction 2.0.0-alpha.11",
+ "penumbra-sdk-community-pool 2.0.0-alpha.11",
+ "penumbra-sdk-compact-block 2.0.0-alpha.11",
+ "penumbra-sdk-dex 2.0.0-alpha.11",
+ "penumbra-sdk-distributions 2.0.0-alpha.11",
+ "penumbra-sdk-fee 2.0.0-alpha.11",
+ "penumbra-sdk-funding 2.0.0-alpha.11",
+ "penumbra-sdk-governance 2.0.0-alpha.11",
+ "penumbra-sdk-ibc 2.0.0-alpha.11",
+ "penumbra-sdk-keys 2.0.0-alpha.11",
+ "penumbra-sdk-num 2.0.0-alpha.11",
+ "penumbra-sdk-proof-params 2.0.0-alpha.11",
+ "penumbra-sdk-proto 2.0.0-alpha.11",
+ "penumbra-sdk-sct 2.0.0-alpha.11",
+ "penumbra-sdk-shielded-pool 2.0.0-alpha.11",
+ "penumbra-sdk-stake 2.0.0-alpha.11",
+ "penumbra-sdk-tct 2.0.0-alpha.11",
+ "penumbra-sdk-tower-trace 2.0.0-alpha.11",
+ "penumbra-sdk-transaction 2.0.0-alpha.11",
+ "penumbra-sdk-txhash 2.0.0-alpha.11",
  "prost 0.13.5",
  "rand_chacha 0.3.1",
  "regex",
@@ -6515,8 +6515,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-asset"
-version = "1.5.1"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v1.5.1#d55e7e80eb42ecb205d88d270644c3e23e2cde36"
+version = "1.5.2"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v1.5.2#07c4ba1381fa76b47878dc231f616ae441266976"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -6529,7 +6529,7 @@ dependencies = [
  "blake2b_simd 1.0.3",
  "bytes",
  "decaf377",
- "decaf377-fmd 1.5.1",
+ "decaf377-fmd 1.5.2",
  "decaf377-rdsa",
  "derivative",
  "ethnum",
@@ -6540,8 +6540,8 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "pbjson-types 0.7.0",
- "penumbra-sdk-num 1.5.1",
- "penumbra-sdk-proto 1.5.1",
+ "penumbra-sdk-num 1.5.2",
+ "penumbra-sdk-proto 1.5.2",
  "poseidon377",
  "rand 0.8.5",
  "rand_core 0.6.4",
@@ -6555,8 +6555,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-asset"
-version = "2.0.0-alpha.10"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.10#c209a52ea26efc5a2f02df0105405e93917fa5c4"
+version = "2.0.0-alpha.11"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -6569,7 +6569,7 @@ dependencies = [
  "blake2b_simd 1.0.3",
  "bytes",
  "decaf377",
- "decaf377-fmd 2.0.0-alpha.10",
+ "decaf377-fmd 2.0.0-alpha.11",
  "decaf377-rdsa",
  "derivative",
  "ethnum",
@@ -6580,8 +6580,8 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "pbjson-types 0.7.0",
- "penumbra-sdk-num 2.0.0-alpha.10",
- "penumbra-sdk-proto 2.0.0-alpha.10",
+ "penumbra-sdk-num 2.0.0-alpha.11",
+ "penumbra-sdk-proto 2.0.0-alpha.11",
  "poseidon377",
  "rand 0.8.5",
  "rand_core 0.6.4",
@@ -6647,8 +6647,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-auction"
-version = "1.5.1"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v1.5.1#d55e7e80eb42ecb205d88d270644c3e23e2cde36"
+version = "1.5.2"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v1.5.2#07c4ba1381fa76b47878dc231f616ae441266976"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -6664,7 +6664,7 @@ dependencies = [
  "bitvec",
  "blake2b_simd 1.0.3",
  "cnidarium 0.83.0",
- "cnidarium-component 1.5.1",
+ "cnidarium-component 1.5.2",
  "decaf377",
  "decaf377-rdsa",
  "futures",
@@ -6672,16 +6672,16 @@ dependencies = [
  "metrics 0.24.2",
  "once_cell",
  "pbjson-types 0.7.0",
- "penumbra-sdk-asset 1.5.1",
- "penumbra-sdk-dex 1.5.1",
- "penumbra-sdk-keys 1.5.1",
- "penumbra-sdk-num 1.5.1",
- "penumbra-sdk-proof-params 1.5.1",
- "penumbra-sdk-proto 1.5.1",
- "penumbra-sdk-sct 1.5.1",
- "penumbra-sdk-shielded-pool 1.5.1",
- "penumbra-sdk-tct 1.5.1",
- "penumbra-sdk-txhash 1.5.1",
+ "penumbra-sdk-asset 1.5.2",
+ "penumbra-sdk-dex 1.5.2",
+ "penumbra-sdk-keys 1.5.2",
+ "penumbra-sdk-num 1.5.2",
+ "penumbra-sdk-proof-params 1.5.2",
+ "penumbra-sdk-proto 1.5.2",
+ "penumbra-sdk-sct 1.5.2",
+ "penumbra-sdk-shielded-pool 1.5.2",
+ "penumbra-sdk-tct 1.5.2",
+ "penumbra-sdk-txhash 1.5.2",
  "prost 0.13.5",
  "prost-types 0.13.5",
  "rand_chacha 0.3.1",
@@ -6699,8 +6699,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-auction"
-version = "2.0.0-alpha.10"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.10#c209a52ea26efc5a2f02df0105405e93917fa5c4"
+version = "2.0.0-alpha.11"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -6716,7 +6716,7 @@ dependencies = [
  "bitvec",
  "blake2b_simd 1.0.3",
  "cnidarium 0.83.0",
- "cnidarium-component 2.0.0-alpha.10",
+ "cnidarium-component 2.0.0-alpha.11",
  "decaf377",
  "decaf377-rdsa",
  "futures",
@@ -6724,16 +6724,16 @@ dependencies = [
  "metrics 0.24.2",
  "once_cell",
  "pbjson-types 0.7.0",
- "penumbra-sdk-asset 2.0.0-alpha.10",
- "penumbra-sdk-dex 2.0.0-alpha.10",
- "penumbra-sdk-keys 2.0.0-alpha.10",
- "penumbra-sdk-num 2.0.0-alpha.10",
- "penumbra-sdk-proof-params 2.0.0-alpha.10",
- "penumbra-sdk-proto 2.0.0-alpha.10",
- "penumbra-sdk-sct 2.0.0-alpha.10",
- "penumbra-sdk-shielded-pool 2.0.0-alpha.10",
- "penumbra-sdk-tct 2.0.0-alpha.10",
- "penumbra-sdk-txhash 2.0.0-alpha.10",
+ "penumbra-sdk-asset 2.0.0-alpha.11",
+ "penumbra-sdk-dex 2.0.0-alpha.11",
+ "penumbra-sdk-keys 2.0.0-alpha.11",
+ "penumbra-sdk-num 2.0.0-alpha.11",
+ "penumbra-sdk-proof-params 2.0.0-alpha.11",
+ "penumbra-sdk-proto 2.0.0-alpha.11",
+ "penumbra-sdk-sct 2.0.0-alpha.11",
+ "penumbra-sdk-shielded-pool 2.0.0-alpha.11",
+ "penumbra-sdk-tct 2.0.0-alpha.11",
+ "penumbra-sdk-txhash 2.0.0-alpha.11",
  "prost 0.13.5",
  "prost-types 0.13.5",
  "rand_chacha 0.3.1",
@@ -6783,65 +6783,69 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-community-pool"
-version = "1.5.1"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v1.5.1#d55e7e80eb42ecb205d88d270644c3e23e2cde36"
+version = "1.5.2"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v1.5.2#07c4ba1381fa76b47878dc231f616ae441266976"
 dependencies = [
  "anyhow",
  "ark-ff",
+ "async-stream",
  "async-trait",
  "base64 0.21.7",
  "blake2b_simd 1.0.3",
  "cnidarium 0.83.0",
- "cnidarium-component 1.5.1",
+ "cnidarium-component 1.5.2",
  "futures",
  "hex",
  "metrics 0.24.2",
  "once_cell",
  "pbjson-types 0.7.0",
- "penumbra-sdk-asset 1.5.1",
- "penumbra-sdk-keys 1.5.1",
- "penumbra-sdk-num 1.5.1",
- "penumbra-sdk-proto 1.5.1",
- "penumbra-sdk-sct 1.5.1",
- "penumbra-sdk-shielded-pool 1.5.1",
- "penumbra-sdk-txhash 1.5.1",
+ "penumbra-sdk-asset 1.5.2",
+ "penumbra-sdk-keys 1.5.2",
+ "penumbra-sdk-num 1.5.2",
+ "penumbra-sdk-proto 1.5.2",
+ "penumbra-sdk-sct 1.5.2",
+ "penumbra-sdk-shielded-pool 1.5.2",
+ "penumbra-sdk-txhash 1.5.2",
  "prost 0.13.5",
  "serde",
  "sha2 0.10.9",
  "tendermint 0.40.3",
  "tendermint-light-client-verifier 0.40.3",
+ "tonic 0.12.3",
  "tracing",
 ]
 
 [[package]]
 name = "penumbra-sdk-community-pool"
-version = "2.0.0-alpha.10"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.10#c209a52ea26efc5a2f02df0105405e93917fa5c4"
+version = "2.0.0-alpha.11"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
 dependencies = [
  "anyhow",
  "ark-ff",
+ "async-stream",
  "async-trait",
  "base64 0.21.7",
  "blake2b_simd 1.0.3",
  "cnidarium 0.83.0",
- "cnidarium-component 2.0.0-alpha.10",
+ "cnidarium-component 2.0.0-alpha.11",
  "futures",
  "hex",
  "metrics 0.24.2",
  "once_cell",
  "pbjson-types 0.7.0",
- "penumbra-sdk-asset 2.0.0-alpha.10",
- "penumbra-sdk-keys 2.0.0-alpha.10",
- "penumbra-sdk-num 2.0.0-alpha.10",
- "penumbra-sdk-proto 2.0.0-alpha.10",
- "penumbra-sdk-sct 2.0.0-alpha.10",
- "penumbra-sdk-shielded-pool 2.0.0-alpha.10",
- "penumbra-sdk-txhash 2.0.0-alpha.10",
+ "penumbra-sdk-asset 2.0.0-alpha.11",
+ "penumbra-sdk-keys 2.0.0-alpha.11",
+ "penumbra-sdk-num 2.0.0-alpha.11",
+ "penumbra-sdk-proto 2.0.0-alpha.11",
+ "penumbra-sdk-sct 2.0.0-alpha.11",
+ "penumbra-sdk-shielded-pool 2.0.0-alpha.11",
+ "penumbra-sdk-txhash 2.0.0-alpha.11",
  "prost 0.13.5",
  "serde",
  "sha2 0.10.9",
  "tendermint 0.40.3",
  "tendermint-light-client-verifier 0.40.3",
+ "tonic 0.12.3",
  "tracing",
 ]
 
@@ -6883,8 +6887,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-compact-block"
-version = "1.5.1"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v1.5.1#d55e7e80eb42ecb205d88d270644c3e23e2cde36"
+version = "1.5.2"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v1.5.2#07c4ba1381fa76b47878dc231f616ae441266976"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -6892,21 +6896,21 @@ dependencies = [
  "blake2b_simd 1.0.3",
  "bytes",
  "cnidarium 0.83.0",
- "cnidarium-component 1.5.1",
+ "cnidarium-component 1.5.2",
  "decaf377-rdsa",
  "futures",
  "im",
  "metrics 0.24.2",
- "penumbra-sdk-dex 1.5.1",
- "penumbra-sdk-fee 1.5.1",
- "penumbra-sdk-governance 1.5.1",
- "penumbra-sdk-ibc 1.5.1",
- "penumbra-sdk-proof-params 1.5.1",
- "penumbra-sdk-proto 1.5.1",
- "penumbra-sdk-sct 1.5.1",
- "penumbra-sdk-shielded-pool 1.5.1",
- "penumbra-sdk-stake 1.5.1",
- "penumbra-sdk-tct 1.5.1",
+ "penumbra-sdk-dex 1.5.2",
+ "penumbra-sdk-fee 1.5.2",
+ "penumbra-sdk-governance 1.5.2",
+ "penumbra-sdk-ibc 1.5.2",
+ "penumbra-sdk-proof-params 1.5.2",
+ "penumbra-sdk-proto 1.5.2",
+ "penumbra-sdk-sct 1.5.2",
+ "penumbra-sdk-shielded-pool 1.5.2",
+ "penumbra-sdk-stake 1.5.2",
+ "penumbra-sdk-tct 1.5.2",
  "rand 0.8.5",
  "rand_core 0.6.4",
  "serde",
@@ -6919,8 +6923,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-compact-block"
-version = "2.0.0-alpha.10"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.10#c209a52ea26efc5a2f02df0105405e93917fa5c4"
+version = "2.0.0-alpha.11"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -6928,21 +6932,21 @@ dependencies = [
  "blake2b_simd 1.0.3",
  "bytes",
  "cnidarium 0.83.0",
- "cnidarium-component 2.0.0-alpha.10",
+ "cnidarium-component 2.0.0-alpha.11",
  "decaf377-rdsa",
  "futures",
  "im",
  "metrics 0.24.2",
- "penumbra-sdk-dex 2.0.0-alpha.10",
- "penumbra-sdk-fee 2.0.0-alpha.10",
- "penumbra-sdk-governance 2.0.0-alpha.10",
- "penumbra-sdk-ibc 2.0.0-alpha.10",
- "penumbra-sdk-proof-params 2.0.0-alpha.10",
- "penumbra-sdk-proto 2.0.0-alpha.10",
- "penumbra-sdk-sct 2.0.0-alpha.10",
- "penumbra-sdk-shielded-pool 2.0.0-alpha.10",
- "penumbra-sdk-stake 2.0.0-alpha.10",
- "penumbra-sdk-tct 2.0.0-alpha.10",
+ "penumbra-sdk-dex 2.0.0-alpha.11",
+ "penumbra-sdk-fee 2.0.0-alpha.11",
+ "penumbra-sdk-governance 2.0.0-alpha.11",
+ "penumbra-sdk-ibc 2.0.0-alpha.11",
+ "penumbra-sdk-proof-params 2.0.0-alpha.11",
+ "penumbra-sdk-proto 2.0.0-alpha.11",
+ "penumbra-sdk-sct 2.0.0-alpha.11",
+ "penumbra-sdk-shielded-pool 2.0.0-alpha.11",
+ "penumbra-sdk-stake 2.0.0-alpha.11",
+ "penumbra-sdk-tct 2.0.0-alpha.11",
  "rand 0.8.5",
  "rand_core 0.6.4",
  "serde",
@@ -7013,8 +7017,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-dex"
-version = "1.5.1"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v1.5.1#d55e7e80eb42ecb205d88d270644c3e23e2cde36"
+version = "1.5.2"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v1.5.2#07c4ba1381fa76b47878dc231f616ae441266976"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -7029,10 +7033,10 @@ dependencies = [
  "bincode",
  "blake2b_simd 1.0.3",
  "cnidarium 0.83.0",
- "cnidarium-component 1.5.1",
+ "cnidarium-component 1.5.2",
  "decaf377",
- "decaf377-fmd 1.5.1",
- "decaf377-ka 1.5.1",
+ "decaf377-fmd 1.5.2",
+ "decaf377-ka 1.5.2",
  "decaf377-rdsa",
  "futures",
  "hex",
@@ -7042,16 +7046,16 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "pbjson-types 0.7.0",
- "penumbra-sdk-asset 1.5.1",
- "penumbra-sdk-fee 1.5.1",
- "penumbra-sdk-keys 1.5.1",
- "penumbra-sdk-num 1.5.1",
- "penumbra-sdk-proof-params 1.5.1",
- "penumbra-sdk-proto 1.5.1",
- "penumbra-sdk-sct 1.5.1",
- "penumbra-sdk-shielded-pool 1.5.1",
- "penumbra-sdk-tct 1.5.1",
- "penumbra-sdk-txhash 1.5.1",
+ "penumbra-sdk-asset 1.5.2",
+ "penumbra-sdk-fee 1.5.2",
+ "penumbra-sdk-keys 1.5.2",
+ "penumbra-sdk-num 1.5.2",
+ "penumbra-sdk-proof-params 1.5.2",
+ "penumbra-sdk-proto 1.5.2",
+ "penumbra-sdk-sct 1.5.2",
+ "penumbra-sdk-shielded-pool 1.5.2",
+ "penumbra-sdk-tct 1.5.2",
+ "penumbra-sdk-txhash 1.5.2",
  "poseidon377",
  "prost 0.13.5",
  "rand_core 0.6.4",
@@ -7071,8 +7075,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-dex"
-version = "2.0.0-alpha.10"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.10#c209a52ea26efc5a2f02df0105405e93917fa5c4"
+version = "2.0.0-alpha.11"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -7087,10 +7091,10 @@ dependencies = [
  "bincode",
  "blake2b_simd 1.0.3",
  "cnidarium 0.83.0",
- "cnidarium-component 2.0.0-alpha.10",
+ "cnidarium-component 2.0.0-alpha.11",
  "decaf377",
- "decaf377-fmd 2.0.0-alpha.10",
- "decaf377-ka 2.0.0-alpha.10",
+ "decaf377-fmd 2.0.0-alpha.11",
+ "decaf377-ka 2.0.0-alpha.11",
  "decaf377-rdsa",
  "futures",
  "hex",
@@ -7100,16 +7104,16 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "pbjson-types 0.7.0",
- "penumbra-sdk-asset 2.0.0-alpha.10",
- "penumbra-sdk-fee 2.0.0-alpha.10",
- "penumbra-sdk-keys 2.0.0-alpha.10",
- "penumbra-sdk-num 2.0.0-alpha.10",
- "penumbra-sdk-proof-params 2.0.0-alpha.10",
- "penumbra-sdk-proto 2.0.0-alpha.10",
- "penumbra-sdk-sct 2.0.0-alpha.10",
- "penumbra-sdk-shielded-pool 2.0.0-alpha.10",
- "penumbra-sdk-tct 2.0.0-alpha.10",
- "penumbra-sdk-txhash 2.0.0-alpha.10",
+ "penumbra-sdk-asset 2.0.0-alpha.11",
+ "penumbra-sdk-fee 2.0.0-alpha.11",
+ "penumbra-sdk-keys 2.0.0-alpha.11",
+ "penumbra-sdk-num 2.0.0-alpha.11",
+ "penumbra-sdk-proof-params 2.0.0-alpha.11",
+ "penumbra-sdk-proto 2.0.0-alpha.11",
+ "penumbra-sdk-sct 2.0.0-alpha.11",
+ "penumbra-sdk-shielded-pool 2.0.0-alpha.11",
+ "penumbra-sdk-tct 2.0.0-alpha.11",
+ "penumbra-sdk-txhash 2.0.0-alpha.11",
  "poseidon377",
  "prost 0.13.5",
  "rand_core 0.6.4",
@@ -7147,17 +7151,17 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-distributions"
-version = "1.5.1"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v1.5.1#d55e7e80eb42ecb205d88d270644c3e23e2cde36"
+version = "1.5.2"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v1.5.2#07c4ba1381fa76b47878dc231f616ae441266976"
 dependencies = [
  "anyhow",
  "async-trait",
  "cnidarium 0.83.0",
- "cnidarium-component 1.5.1",
- "penumbra-sdk-asset 1.5.1",
- "penumbra-sdk-num 1.5.1",
- "penumbra-sdk-proto 1.5.1",
- "penumbra-sdk-sct 1.5.1",
+ "cnidarium-component 1.5.2",
+ "penumbra-sdk-asset 1.5.2",
+ "penumbra-sdk-num 1.5.2",
+ "penumbra-sdk-proto 1.5.2",
+ "penumbra-sdk-sct 1.5.2",
  "serde",
  "tendermint 0.40.3",
  "tracing",
@@ -7165,17 +7169,17 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-distributions"
-version = "2.0.0-alpha.10"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.10#c209a52ea26efc5a2f02df0105405e93917fa5c4"
+version = "2.0.0-alpha.11"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
 dependencies = [
  "anyhow",
  "async-trait",
  "cnidarium 0.83.0",
- "cnidarium-component 2.0.0-alpha.10",
- "penumbra-sdk-asset 2.0.0-alpha.10",
- "penumbra-sdk-num 2.0.0-alpha.10",
- "penumbra-sdk-proto 2.0.0-alpha.10",
- "penumbra-sdk-sct 2.0.0-alpha.10",
+ "cnidarium-component 2.0.0-alpha.11",
+ "penumbra-sdk-asset 2.0.0-alpha.11",
+ "penumbra-sdk-num 2.0.0-alpha.11",
+ "penumbra-sdk-proto 2.0.0-alpha.11",
+ "penumbra-sdk-sct 2.0.0-alpha.11",
  "serde",
  "tendermint 0.40.3",
  "tonic 0.12.3",
@@ -7211,8 +7215,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-fee"
-version = "1.5.1"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v1.5.1#d55e7e80eb42ecb205d88d270644c3e23e2cde36"
+version = "1.5.2"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v1.5.2#07c4ba1381fa76b47878dc231f616ae441266976"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -7220,14 +7224,14 @@ dependencies = [
  "blake2b_simd 1.0.3",
  "bytes",
  "cnidarium 0.83.0",
- "cnidarium-component 1.5.1",
+ "cnidarium-component 1.5.2",
  "decaf377",
  "decaf377-rdsa",
  "im",
  "metrics 0.24.2",
- "penumbra-sdk-asset 1.5.1",
- "penumbra-sdk-num 1.5.1",
- "penumbra-sdk-proto 1.5.1",
+ "penumbra-sdk-asset 1.5.2",
+ "penumbra-sdk-num 1.5.2",
+ "penumbra-sdk-proto 1.5.2",
  "rand 0.8.5",
  "rand_core 0.6.4",
  "serde",
@@ -7238,8 +7242,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-fee"
-version = "2.0.0-alpha.10"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.10#c209a52ea26efc5a2f02df0105405e93917fa5c4"
+version = "2.0.0-alpha.11"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -7247,14 +7251,14 @@ dependencies = [
  "blake2b_simd 1.0.3",
  "bytes",
  "cnidarium 0.83.0",
- "cnidarium-component 2.0.0-alpha.10",
+ "cnidarium-component 2.0.0-alpha.11",
  "decaf377",
  "decaf377-rdsa",
  "im",
  "metrics 0.24.2",
- "penumbra-sdk-asset 2.0.0-alpha.10",
- "penumbra-sdk-num 2.0.0-alpha.10",
- "penumbra-sdk-proto 2.0.0-alpha.10",
+ "penumbra-sdk-asset 2.0.0-alpha.11",
+ "penumbra-sdk-num 2.0.0-alpha.11",
+ "penumbra-sdk-proto 2.0.0-alpha.11",
  "rand 0.8.5",
  "rand_core 0.6.4",
  "serde",
@@ -7289,23 +7293,23 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-funding"
-version = "1.5.1"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v1.5.1#d55e7e80eb42ecb205d88d270644c3e23e2cde36"
+version = "1.5.2"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v1.5.2#07c4ba1381fa76b47878dc231f616ae441266976"
 dependencies = [
  "anyhow",
  "async-trait",
  "cnidarium 0.83.0",
- "cnidarium-component 1.5.1",
+ "cnidarium-component 1.5.2",
  "futures",
  "metrics 0.24.2",
- "penumbra-sdk-asset 1.5.1",
- "penumbra-sdk-community-pool 1.5.1",
- "penumbra-sdk-distributions 1.5.1",
- "penumbra-sdk-num 1.5.1",
- "penumbra-sdk-proto 1.5.1",
- "penumbra-sdk-sct 1.5.1",
- "penumbra-sdk-shielded-pool 1.5.1",
- "penumbra-sdk-stake 1.5.1",
+ "penumbra-sdk-asset 1.5.2",
+ "penumbra-sdk-community-pool 1.5.2",
+ "penumbra-sdk-distributions 1.5.2",
+ "penumbra-sdk-num 1.5.2",
+ "penumbra-sdk-proto 1.5.2",
+ "penumbra-sdk-sct 1.5.2",
+ "penumbra-sdk-shielded-pool 1.5.2",
+ "penumbra-sdk-stake 1.5.2",
  "serde",
  "tendermint 0.40.3",
  "tracing",
@@ -7313,33 +7317,33 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-funding"
-version = "2.0.0-alpha.10"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.10#c209a52ea26efc5a2f02df0105405e93917fa5c4"
+version = "2.0.0-alpha.11"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
 dependencies = [
  "anyhow",
  "ark-groth16",
  "async-trait",
  "base64 0.21.7",
  "cnidarium 0.83.0",
- "cnidarium-component 2.0.0-alpha.10",
+ "cnidarium-component 2.0.0-alpha.11",
  "decaf377",
  "decaf377-rdsa",
  "futures",
  "metrics 0.24.2",
- "penumbra-sdk-asset 2.0.0-alpha.10",
- "penumbra-sdk-community-pool 2.0.0-alpha.10",
- "penumbra-sdk-dex 2.0.0-alpha.10",
- "penumbra-sdk-distributions 2.0.0-alpha.10",
- "penumbra-sdk-governance 2.0.0-alpha.10",
- "penumbra-sdk-keys 2.0.0-alpha.10",
- "penumbra-sdk-num 2.0.0-alpha.10",
- "penumbra-sdk-proof-params 2.0.0-alpha.10",
- "penumbra-sdk-proto 2.0.0-alpha.10",
- "penumbra-sdk-sct 2.0.0-alpha.10",
- "penumbra-sdk-shielded-pool 2.0.0-alpha.10",
- "penumbra-sdk-stake 2.0.0-alpha.10",
- "penumbra-sdk-tct 2.0.0-alpha.10",
- "penumbra-sdk-txhash 2.0.0-alpha.10",
+ "penumbra-sdk-asset 2.0.0-alpha.11",
+ "penumbra-sdk-community-pool 2.0.0-alpha.11",
+ "penumbra-sdk-dex 2.0.0-alpha.11",
+ "penumbra-sdk-distributions 2.0.0-alpha.11",
+ "penumbra-sdk-governance 2.0.0-alpha.11",
+ "penumbra-sdk-keys 2.0.0-alpha.11",
+ "penumbra-sdk-num 2.0.0-alpha.11",
+ "penumbra-sdk-proof-params 2.0.0-alpha.11",
+ "penumbra-sdk-proto 2.0.0-alpha.11",
+ "penumbra-sdk-sct 2.0.0-alpha.11",
+ "penumbra-sdk-shielded-pool 2.0.0-alpha.11",
+ "penumbra-sdk-stake 2.0.0-alpha.11",
+ "penumbra-sdk-tct 2.0.0-alpha.11",
+ "penumbra-sdk-txhash 2.0.0-alpha.11",
  "rand 0.8.5",
  "serde",
  "tendermint 0.40.3",
@@ -7402,8 +7406,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-governance"
-version = "1.5.1"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v1.5.1#d55e7e80eb42ecb205d88d270644c3e23e2cde36"
+version = "1.5.2"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v1.5.2#07c4ba1381fa76b47878dc231f616ae441266976"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -7418,7 +7422,7 @@ dependencies = [
  "blake2b_simd 1.0.3",
  "bytes",
  "cnidarium 0.83.0",
- "cnidarium-component 1.5.1",
+ "cnidarium-component 1.5.2",
  "decaf377",
  "decaf377-rdsa",
  "futures",
@@ -7427,18 +7431,18 @@ dependencies = [
  "metrics 0.24.2",
  "once_cell",
  "pbjson-types 0.7.0",
- "penumbra-sdk-asset 1.5.1",
- "penumbra-sdk-distributions 1.5.1",
- "penumbra-sdk-ibc 1.5.1",
- "penumbra-sdk-keys 1.5.1",
- "penumbra-sdk-num 1.5.1",
- "penumbra-sdk-proof-params 1.5.1",
- "penumbra-sdk-proto 1.5.1",
- "penumbra-sdk-sct 1.5.1",
- "penumbra-sdk-shielded-pool 1.5.1",
- "penumbra-sdk-stake 1.5.1",
- "penumbra-sdk-tct 1.5.1",
- "penumbra-sdk-txhash 1.5.1",
+ "penumbra-sdk-asset 1.5.2",
+ "penumbra-sdk-distributions 1.5.2",
+ "penumbra-sdk-ibc 1.5.2",
+ "penumbra-sdk-keys 1.5.2",
+ "penumbra-sdk-num 1.5.2",
+ "penumbra-sdk-proof-params 1.5.2",
+ "penumbra-sdk-proto 1.5.2",
+ "penumbra-sdk-sct 1.5.2",
+ "penumbra-sdk-shielded-pool 1.5.2",
+ "penumbra-sdk-stake 1.5.2",
+ "penumbra-sdk-tct 1.5.2",
+ "penumbra-sdk-txhash 1.5.2",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
@@ -7455,8 +7459,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-governance"
-version = "2.0.0-alpha.10"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.10#c209a52ea26efc5a2f02df0105405e93917fa5c4"
+version = "2.0.0-alpha.11"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -7471,7 +7475,7 @@ dependencies = [
  "blake2b_simd 1.0.3",
  "bytes",
  "cnidarium 0.83.0",
- "cnidarium-component 2.0.0-alpha.10",
+ "cnidarium-component 2.0.0-alpha.11",
  "decaf377",
  "decaf377-rdsa",
  "futures",
@@ -7480,18 +7484,18 @@ dependencies = [
  "metrics 0.24.2",
  "once_cell",
  "pbjson-types 0.7.0",
- "penumbra-sdk-asset 2.0.0-alpha.10",
- "penumbra-sdk-distributions 2.0.0-alpha.10",
- "penumbra-sdk-ibc 2.0.0-alpha.10",
- "penumbra-sdk-keys 2.0.0-alpha.10",
- "penumbra-sdk-num 2.0.0-alpha.10",
- "penumbra-sdk-proof-params 2.0.0-alpha.10",
- "penumbra-sdk-proto 2.0.0-alpha.10",
- "penumbra-sdk-sct 2.0.0-alpha.10",
- "penumbra-sdk-shielded-pool 2.0.0-alpha.10",
- "penumbra-sdk-stake 2.0.0-alpha.10",
- "penumbra-sdk-tct 2.0.0-alpha.10",
- "penumbra-sdk-txhash 2.0.0-alpha.10",
+ "penumbra-sdk-asset 2.0.0-alpha.11",
+ "penumbra-sdk-distributions 2.0.0-alpha.11",
+ "penumbra-sdk-ibc 2.0.0-alpha.11",
+ "penumbra-sdk-keys 2.0.0-alpha.11",
+ "penumbra-sdk-num 2.0.0-alpha.11",
+ "penumbra-sdk-proof-params 2.0.0-alpha.11",
+ "penumbra-sdk-proto 2.0.0-alpha.11",
+ "penumbra-sdk-sct 2.0.0-alpha.11",
+ "penumbra-sdk-shielded-pool 2.0.0-alpha.11",
+ "penumbra-sdk-stake 2.0.0-alpha.11",
+ "penumbra-sdk-tct 2.0.0-alpha.11",
+ "penumbra-sdk-txhash 2.0.0-alpha.11",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
@@ -7545,8 +7549,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-ibc"
-version = "1.5.1"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v1.5.1#d55e7e80eb42ecb205d88d270644c3e23e2cde36"
+version = "1.5.2"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v1.5.2#07c4ba1381fa76b47878dc231f616ae441266976"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -7563,11 +7567,11 @@ dependencies = [
  "num-traits",
  "once_cell",
  "pbjson-types 0.7.0",
- "penumbra-sdk-asset 1.5.1",
- "penumbra-sdk-num 1.5.1",
- "penumbra-sdk-proto 1.5.1",
- "penumbra-sdk-sct 1.5.1",
- "penumbra-sdk-txhash 1.5.1",
+ "penumbra-sdk-asset 1.5.2",
+ "penumbra-sdk-num 1.5.2",
+ "penumbra-sdk-proto 1.5.2",
+ "penumbra-sdk-sct 1.5.2",
+ "penumbra-sdk-txhash 1.5.2",
  "prost 0.13.5",
  "serde",
  "serde_json",
@@ -7582,8 +7586,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-ibc"
-version = "2.0.0-alpha.10"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.10#c209a52ea26efc5a2f02df0105405e93917fa5c4"
+version = "2.0.0-alpha.11"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -7600,11 +7604,11 @@ dependencies = [
  "num-traits",
  "once_cell",
  "pbjson-types 0.7.0",
- "penumbra-sdk-asset 2.0.0-alpha.10",
- "penumbra-sdk-num 2.0.0-alpha.10",
- "penumbra-sdk-proto 2.0.0-alpha.10",
- "penumbra-sdk-sct 2.0.0-alpha.10",
- "penumbra-sdk-txhash 2.0.0-alpha.10",
+ "penumbra-sdk-asset 2.0.0-alpha.11",
+ "penumbra-sdk-num 2.0.0-alpha.11",
+ "penumbra-sdk-proto 2.0.0-alpha.11",
+ "penumbra-sdk-sct 2.0.0-alpha.11",
+ "penumbra-sdk-txhash 2.0.0-alpha.11",
  "prost 0.13.5",
  "serde",
  "serde_json",
@@ -7663,8 +7667,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-keys"
-version = "1.5.1"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v1.5.1#d55e7e80eb42ecb205d88d270644c3e23e2cde36"
+version = "1.5.2"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v1.5.2#07c4ba1381fa76b47878dc231f616ae441266976"
 dependencies = [
  "aes",
  "anyhow",
@@ -7680,8 +7684,8 @@ dependencies = [
  "bytes",
  "chacha20poly1305",
  "decaf377",
- "decaf377-fmd 1.5.1",
- "decaf377-ka 1.5.1",
+ "decaf377-fmd 1.5.2",
+ "decaf377-ka 1.5.2",
  "decaf377-rdsa",
  "derivative",
  "ethnum",
@@ -7692,9 +7696,9 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "pbkdf2",
- "penumbra-sdk-asset 1.5.1",
- "penumbra-sdk-proto 1.5.1",
- "penumbra-sdk-tct 1.5.1",
+ "penumbra-sdk-asset 1.5.2",
+ "penumbra-sdk-proto 1.5.2",
+ "penumbra-sdk-tct 1.5.2",
  "poseidon377",
  "rand 0.8.5",
  "rand_core 0.6.4",
@@ -7707,8 +7711,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-keys"
-version = "2.0.0-alpha.10"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.10#c209a52ea26efc5a2f02df0105405e93917fa5c4"
+version = "2.0.0-alpha.11"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
 dependencies = [
  "aes",
  "anyhow",
@@ -7724,8 +7728,8 @@ dependencies = [
  "bytes",
  "chacha20poly1305",
  "decaf377",
- "decaf377-fmd 2.0.0-alpha.10",
- "decaf377-ka 2.0.0-alpha.10",
+ "decaf377-fmd 2.0.0-alpha.11",
+ "decaf377-ka 2.0.0-alpha.11",
  "decaf377-rdsa",
  "derivative",
  "ethnum",
@@ -7736,9 +7740,9 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "pbkdf2",
- "penumbra-sdk-asset 2.0.0-alpha.10",
- "penumbra-sdk-proto 2.0.0-alpha.10",
- "penumbra-sdk-tct 2.0.0-alpha.10",
+ "penumbra-sdk-asset 2.0.0-alpha.11",
+ "penumbra-sdk-proto 2.0.0-alpha.11",
+ "penumbra-sdk-tct 2.0.0-alpha.11",
  "poseidon377",
  "rand 0.8.5",
  "rand_core 0.6.4",
@@ -7787,8 +7791,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-num"
-version = "1.5.1"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v1.5.1#d55e7e80eb42ecb205d88d270644c3e23e2cde36"
+version = "1.5.2"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v1.5.2#07c4ba1381fa76b47878dc231f616ae441266976"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -7803,7 +7807,7 @@ dependencies = [
  "blake2b_simd 1.0.3",
  "bytes",
  "decaf377",
- "decaf377-fmd 1.5.1",
+ "decaf377-fmd 1.5.2",
  "decaf377-rdsa",
  "derivative",
  "ethnum",
@@ -7811,7 +7815,7 @@ dependencies = [
  "ibig",
  "num-bigint",
  "once_cell",
- "penumbra-sdk-proto 1.5.1",
+ "penumbra-sdk-proto 1.5.2",
  "rand 0.8.5",
  "rand_core 0.6.4",
  "regex",
@@ -7823,8 +7827,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-num"
-version = "2.0.0-alpha.10"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.10#c209a52ea26efc5a2f02df0105405e93917fa5c4"
+version = "2.0.0-alpha.11"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -7839,7 +7843,7 @@ dependencies = [
  "blake2b_simd 1.0.3",
  "bytes",
  "decaf377",
- "decaf377-fmd 2.0.0-alpha.10",
+ "decaf377-fmd 2.0.0-alpha.11",
  "decaf377-rdsa",
  "derivative",
  "ethnum",
@@ -7847,7 +7851,7 @@ dependencies = [
  "ibig",
  "num-bigint",
  "once_cell",
- "penumbra-sdk-proto 2.0.0-alpha.10",
+ "penumbra-sdk-proto 2.0.0-alpha.11",
  "rand 0.8.5",
  "rand_core 0.6.4",
  "regex",
@@ -7884,8 +7888,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-proof-params"
-version = "1.5.1"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v1.5.1#d55e7e80eb42ecb205d88d270644c3e23e2cde36"
+version = "1.5.2"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v1.5.2#07c4ba1381fa76b47878dc231f616ae441266976"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -7909,8 +7913,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-proof-params"
-version = "2.0.0-alpha.10"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.10#c209a52ea26efc5a2f02df0105405e93917fa5c4"
+version = "2.0.0-alpha.11"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -7963,15 +7967,15 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-proto"
-version = "1.5.1"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v1.5.1#d55e7e80eb42ecb205d88d270644c3e23e2cde36"
+version = "1.5.2"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v1.5.2#07c4ba1381fa76b47878dc231f616ae441266976"
 dependencies = [
  "anyhow",
  "async-trait",
  "bech32",
  "bytes",
  "cnidarium 0.83.0",
- "decaf377-fmd 1.5.1",
+ "decaf377-fmd 1.5.2",
  "decaf377-rdsa",
  "futures",
  "hex",
@@ -7992,15 +7996,15 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-proto"
-version = "2.0.0-alpha.10"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.10#c209a52ea26efc5a2f02df0105405e93917fa5c4"
+version = "2.0.0-alpha.11"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
 dependencies = [
  "anyhow",
  "async-trait",
  "bech32",
  "bytes",
  "cnidarium 0.83.0",
- "decaf377-fmd 2.0.0-alpha.10",
+ "decaf377-fmd 2.0.0-alpha.11",
  "decaf377-rdsa",
  "futures",
  "hex",
@@ -8057,8 +8061,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-sct"
-version = "1.5.1"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v1.5.1#d55e7e80eb42ecb205d88d270644c3e23e2cde36"
+version = "1.5.2"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v1.5.2#07c4ba1381fa76b47878dc231f616ae441266976"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -8071,7 +8075,7 @@ dependencies = [
  "bytes",
  "chrono",
  "cnidarium 0.83.0",
- "cnidarium-component 1.5.1",
+ "cnidarium-component 1.5.2",
  "decaf377",
  "decaf377-rdsa",
  "hex",
@@ -8079,9 +8083,9 @@ dependencies = [
  "metrics 0.24.2",
  "once_cell",
  "pbjson-types 0.7.0",
- "penumbra-sdk-keys 1.5.1",
- "penumbra-sdk-proto 1.5.1",
- "penumbra-sdk-tct 1.5.1",
+ "penumbra-sdk-keys 1.5.2",
+ "penumbra-sdk-proto 1.5.2",
+ "penumbra-sdk-tct 1.5.2",
  "poseidon377",
  "rand 0.8.5",
  "rand_core 0.6.4",
@@ -8093,8 +8097,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-sct"
-version = "2.0.0-alpha.10"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.10#c209a52ea26efc5a2f02df0105405e93917fa5c4"
+version = "2.0.0-alpha.11"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -8107,7 +8111,7 @@ dependencies = [
  "bytes",
  "chrono",
  "cnidarium 0.83.0",
- "cnidarium-component 2.0.0-alpha.10",
+ "cnidarium-component 2.0.0-alpha.11",
  "decaf377",
  "decaf377-rdsa",
  "hex",
@@ -8115,10 +8119,10 @@ dependencies = [
  "metrics 0.24.2",
  "once_cell",
  "pbjson-types 0.7.0",
- "penumbra-sdk-keys 2.0.0-alpha.10",
- "penumbra-sdk-proto 2.0.0-alpha.10",
- "penumbra-sdk-tct 2.0.0-alpha.10",
- "penumbra-sdk-txhash 2.0.0-alpha.10",
+ "penumbra-sdk-keys 2.0.0-alpha.11",
+ "penumbra-sdk-proto 2.0.0-alpha.11",
+ "penumbra-sdk-tct 2.0.0-alpha.11",
+ "penumbra-sdk-txhash 2.0.0-alpha.11",
  "poseidon377",
  "rand 0.8.5",
  "rand_core 0.6.4",
@@ -8184,8 +8188,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-shielded-pool"
-version = "1.5.1"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v1.5.1#d55e7e80eb42ecb205d88d270644c3e23e2cde36"
+version = "1.5.2"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v1.5.2#07c4ba1381fa76b47878dc231f616ae441266976"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -8201,10 +8205,10 @@ dependencies = [
  "bytes",
  "chacha20poly1305",
  "cnidarium 0.83.0",
- "cnidarium-component 1.5.1",
+ "cnidarium-component 1.5.2",
  "decaf377",
- "decaf377-fmd 1.5.1",
- "decaf377-ka 1.5.1",
+ "decaf377-fmd 1.5.2",
+ "decaf377-ka 1.5.2",
  "decaf377-rdsa",
  "futures",
  "hex",
@@ -8213,15 +8217,15 @@ dependencies = [
  "im",
  "metrics 0.24.2",
  "once_cell",
- "penumbra-sdk-asset 1.5.1",
- "penumbra-sdk-ibc 1.5.1",
- "penumbra-sdk-keys 1.5.1",
- "penumbra-sdk-num 1.5.1",
- "penumbra-sdk-proof-params 1.5.1",
- "penumbra-sdk-proto 1.5.1",
- "penumbra-sdk-sct 1.5.1",
- "penumbra-sdk-tct 1.5.1",
- "penumbra-sdk-txhash 1.5.1",
+ "penumbra-sdk-asset 1.5.2",
+ "penumbra-sdk-ibc 1.5.2",
+ "penumbra-sdk-keys 1.5.2",
+ "penumbra-sdk-num 1.5.2",
+ "penumbra-sdk-proof-params 1.5.2",
+ "penumbra-sdk-proto 1.5.2",
+ "penumbra-sdk-sct 1.5.2",
+ "penumbra-sdk-tct 1.5.2",
+ "penumbra-sdk-txhash 1.5.2",
  "poseidon377",
  "prost 0.13.5",
  "rand 0.8.5",
@@ -8238,8 +8242,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-shielded-pool"
-version = "2.0.0-alpha.10"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.10#c209a52ea26efc5a2f02df0105405e93917fa5c4"
+version = "2.0.0-alpha.11"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -8255,10 +8259,10 @@ dependencies = [
  "bytes",
  "chacha20poly1305",
  "cnidarium 0.83.0",
- "cnidarium-component 2.0.0-alpha.10",
+ "cnidarium-component 2.0.0-alpha.11",
  "decaf377",
- "decaf377-fmd 2.0.0-alpha.10",
- "decaf377-ka 2.0.0-alpha.10",
+ "decaf377-fmd 2.0.0-alpha.11",
+ "decaf377-ka 2.0.0-alpha.11",
  "decaf377-rdsa",
  "futures",
  "hex",
@@ -8267,15 +8271,15 @@ dependencies = [
  "im",
  "metrics 0.24.2",
  "once_cell",
- "penumbra-sdk-asset 2.0.0-alpha.10",
- "penumbra-sdk-ibc 2.0.0-alpha.10",
- "penumbra-sdk-keys 2.0.0-alpha.10",
- "penumbra-sdk-num 2.0.0-alpha.10",
- "penumbra-sdk-proof-params 2.0.0-alpha.10",
- "penumbra-sdk-proto 2.0.0-alpha.10",
- "penumbra-sdk-sct 2.0.0-alpha.10",
- "penumbra-sdk-tct 2.0.0-alpha.10",
- "penumbra-sdk-txhash 2.0.0-alpha.10",
+ "penumbra-sdk-asset 2.0.0-alpha.11",
+ "penumbra-sdk-ibc 2.0.0-alpha.11",
+ "penumbra-sdk-keys 2.0.0-alpha.11",
+ "penumbra-sdk-num 2.0.0-alpha.11",
+ "penumbra-sdk-proof-params 2.0.0-alpha.11",
+ "penumbra-sdk-proto 2.0.0-alpha.11",
+ "penumbra-sdk-sct 2.0.0-alpha.11",
+ "penumbra-sdk-tct 2.0.0-alpha.11",
+ "penumbra-sdk-txhash 2.0.0-alpha.11",
  "poseidon377",
  "prost 0.13.5",
  "rand 0.8.5",
@@ -8342,8 +8346,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-stake"
-version = "1.5.1"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v1.5.1#d55e7e80eb42ecb205d88d270644c3e23e2cde36"
+version = "1.5.2"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v1.5.2#07c4ba1381fa76b47878dc231f616ae441266976"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -8358,7 +8362,7 @@ dependencies = [
  "bech32",
  "bitvec",
  "cnidarium 0.83.0",
- "cnidarium-component 1.5.1",
+ "cnidarium-component 1.5.2",
  "decaf377",
  "decaf377-rdsa",
  "futures",
@@ -8366,16 +8370,16 @@ dependencies = [
  "im",
  "metrics 0.24.2",
  "once_cell",
- "penumbra-sdk-asset 1.5.1",
- "penumbra-sdk-distributions 1.5.1",
- "penumbra-sdk-keys 1.5.1",
- "penumbra-sdk-num 1.5.1",
- "penumbra-sdk-proof-params 1.5.1",
- "penumbra-sdk-proto 1.5.1",
- "penumbra-sdk-sct 1.5.1",
- "penumbra-sdk-shielded-pool 1.5.1",
- "penumbra-sdk-tct 1.5.1",
- "penumbra-sdk-txhash 1.5.1",
+ "penumbra-sdk-asset 1.5.2",
+ "penumbra-sdk-distributions 1.5.2",
+ "penumbra-sdk-keys 1.5.2",
+ "penumbra-sdk-num 1.5.2",
+ "penumbra-sdk-proof-params 1.5.2",
+ "penumbra-sdk-proto 1.5.2",
+ "penumbra-sdk-sct 1.5.2",
+ "penumbra-sdk-shielded-pool 1.5.2",
+ "penumbra-sdk-tct 1.5.2",
+ "penumbra-sdk-txhash 1.5.2",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "regex",
@@ -8392,8 +8396,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-stake"
-version = "2.0.0-alpha.10"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.10#c209a52ea26efc5a2f02df0105405e93917fa5c4"
+version = "2.0.0-alpha.11"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -8408,7 +8412,7 @@ dependencies = [
  "bech32",
  "bitvec",
  "cnidarium 0.83.0",
- "cnidarium-component 2.0.0-alpha.10",
+ "cnidarium-component 2.0.0-alpha.11",
  "decaf377",
  "decaf377-rdsa",
  "futures",
@@ -8416,16 +8420,16 @@ dependencies = [
  "im",
  "metrics 0.24.2",
  "once_cell",
- "penumbra-sdk-asset 2.0.0-alpha.10",
- "penumbra-sdk-distributions 2.0.0-alpha.10",
- "penumbra-sdk-keys 2.0.0-alpha.10",
- "penumbra-sdk-num 2.0.0-alpha.10",
- "penumbra-sdk-proof-params 2.0.0-alpha.10",
- "penumbra-sdk-proto 2.0.0-alpha.10",
- "penumbra-sdk-sct 2.0.0-alpha.10",
- "penumbra-sdk-shielded-pool 2.0.0-alpha.10",
- "penumbra-sdk-tct 2.0.0-alpha.10",
- "penumbra-sdk-txhash 2.0.0-alpha.10",
+ "penumbra-sdk-asset 2.0.0-alpha.11",
+ "penumbra-sdk-distributions 2.0.0-alpha.11",
+ "penumbra-sdk-keys 2.0.0-alpha.11",
+ "penumbra-sdk-num 2.0.0-alpha.11",
+ "penumbra-sdk-proof-params 2.0.0-alpha.11",
+ "penumbra-sdk-proto 2.0.0-alpha.11",
+ "penumbra-sdk-sct 2.0.0-alpha.11",
+ "penumbra-sdk-shielded-pool 2.0.0-alpha.11",
+ "penumbra-sdk-tct 2.0.0-alpha.11",
+ "penumbra-sdk-txhash 2.0.0-alpha.11",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "regex",
@@ -8471,8 +8475,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-tct"
-version = "1.5.1"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v1.5.1#d55e7e80eb42ecb205d88d270644c3e23e2cde36"
+version = "1.5.2"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v1.5.2#07c4ba1381fa76b47878dc231f616ae441266976"
 dependencies = [
  "ark-ed-on-bls12-377",
  "ark-ff",
@@ -8490,7 +8494,7 @@ dependencies = [
  "im",
  "once_cell",
  "parking_lot",
- "penumbra-sdk-proto 1.5.1",
+ "penumbra-sdk-proto 1.5.2",
  "poseidon377",
  "rand 0.8.5",
  "serde",
@@ -8500,8 +8504,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-tct"
-version = "2.0.0-alpha.10"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.10#c209a52ea26efc5a2f02df0105405e93917fa5c4"
+version = "2.0.0-alpha.11"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
 dependencies = [
  "ark-ed-on-bls12-377",
  "ark-ff",
@@ -8519,7 +8523,7 @@ dependencies = [
  "im",
  "once_cell",
  "parking_lot",
- "penumbra-sdk-proto 2.0.0-alpha.10",
+ "penumbra-sdk-proto 2.0.0-alpha.11",
  "poseidon377",
  "rand 0.8.5",
  "serde",
@@ -8551,8 +8555,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-tower-trace"
-version = "1.5.1"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v1.5.1#d55e7e80eb42ecb205d88d270644c3e23e2cde36"
+version = "1.5.2"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v1.5.2#07c4ba1381fa76b47878dc231f616ae441266976"
 dependencies = [
  "futures",
  "hex",
@@ -8573,8 +8577,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-tower-trace"
-version = "2.0.0-alpha.10"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.10#c209a52ea26efc5a2f02df0105405e93917fa5c4"
+version = "2.0.0-alpha.11"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
 dependencies = [
  "futures",
  "hex",
@@ -8647,8 +8651,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-transaction"
-version = "1.5.1"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v1.5.1#d55e7e80eb42ecb205d88d270644c3e23e2cde36"
+version = "1.5.2"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v1.5.2#07c4ba1381fa76b47878dc231f616ae441266976"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -8659,8 +8663,8 @@ dependencies = [
  "bytes",
  "chacha20poly1305",
  "decaf377",
- "decaf377-fmd 1.5.1",
- "decaf377-ka 1.5.1",
+ "decaf377-fmd 1.5.2",
+ "decaf377-ka 1.5.2",
  "decaf377-rdsa",
  "derivative",
  "hex",
@@ -8669,22 +8673,22 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "pbjson-types 0.7.0",
- "penumbra-sdk-asset 1.5.1",
- "penumbra-sdk-auction 1.5.1",
- "penumbra-sdk-community-pool 1.5.1",
- "penumbra-sdk-dex 1.5.1",
- "penumbra-sdk-fee 1.5.1",
- "penumbra-sdk-governance 1.5.1",
- "penumbra-sdk-ibc 1.5.1",
- "penumbra-sdk-keys 1.5.1",
- "penumbra-sdk-num 1.5.1",
- "penumbra-sdk-proof-params 1.5.1",
- "penumbra-sdk-proto 1.5.1",
- "penumbra-sdk-sct 1.5.1",
- "penumbra-sdk-shielded-pool 1.5.1",
- "penumbra-sdk-stake 1.5.1",
- "penumbra-sdk-tct 1.5.1",
- "penumbra-sdk-txhash 1.5.1",
+ "penumbra-sdk-asset 1.5.2",
+ "penumbra-sdk-auction 1.5.2",
+ "penumbra-sdk-community-pool 1.5.2",
+ "penumbra-sdk-dex 1.5.2",
+ "penumbra-sdk-fee 1.5.2",
+ "penumbra-sdk-governance 1.5.2",
+ "penumbra-sdk-ibc 1.5.2",
+ "penumbra-sdk-keys 1.5.2",
+ "penumbra-sdk-num 1.5.2",
+ "penumbra-sdk-proof-params 1.5.2",
+ "penumbra-sdk-proto 1.5.2",
+ "penumbra-sdk-sct 1.5.2",
+ "penumbra-sdk-shielded-pool 1.5.2",
+ "penumbra-sdk-stake 1.5.2",
+ "penumbra-sdk-tct 1.5.2",
+ "penumbra-sdk-txhash 1.5.2",
  "poseidon377",
  "rand 0.8.5",
  "rand_core 0.6.4",
@@ -8699,8 +8703,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-transaction"
-version = "2.0.0-alpha.10"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.10#c209a52ea26efc5a2f02df0105405e93917fa5c4"
+version = "2.0.0-alpha.11"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -8711,8 +8715,8 @@ dependencies = [
  "bytes",
  "chacha20poly1305",
  "decaf377",
- "decaf377-fmd 2.0.0-alpha.10",
- "decaf377-ka 2.0.0-alpha.10",
+ "decaf377-fmd 2.0.0-alpha.11",
+ "decaf377-ka 2.0.0-alpha.11",
  "decaf377-rdsa",
  "derivative",
  "hex",
@@ -8721,23 +8725,23 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "pbjson-types 0.7.0",
- "penumbra-sdk-asset 2.0.0-alpha.10",
- "penumbra-sdk-auction 2.0.0-alpha.10",
- "penumbra-sdk-community-pool 2.0.0-alpha.10",
- "penumbra-sdk-dex 2.0.0-alpha.10",
- "penumbra-sdk-fee 2.0.0-alpha.10",
- "penumbra-sdk-funding 2.0.0-alpha.10",
- "penumbra-sdk-governance 2.0.0-alpha.10",
- "penumbra-sdk-ibc 2.0.0-alpha.10",
- "penumbra-sdk-keys 2.0.0-alpha.10",
- "penumbra-sdk-num 2.0.0-alpha.10",
- "penumbra-sdk-proof-params 2.0.0-alpha.10",
- "penumbra-sdk-proto 2.0.0-alpha.10",
- "penumbra-sdk-sct 2.0.0-alpha.10",
- "penumbra-sdk-shielded-pool 2.0.0-alpha.10",
- "penumbra-sdk-stake 2.0.0-alpha.10",
- "penumbra-sdk-tct 2.0.0-alpha.10",
- "penumbra-sdk-txhash 2.0.0-alpha.10",
+ "penumbra-sdk-asset 2.0.0-alpha.11",
+ "penumbra-sdk-auction 2.0.0-alpha.11",
+ "penumbra-sdk-community-pool 2.0.0-alpha.11",
+ "penumbra-sdk-dex 2.0.0-alpha.11",
+ "penumbra-sdk-fee 2.0.0-alpha.11",
+ "penumbra-sdk-funding 2.0.0-alpha.11",
+ "penumbra-sdk-governance 2.0.0-alpha.11",
+ "penumbra-sdk-ibc 2.0.0-alpha.11",
+ "penumbra-sdk-keys 2.0.0-alpha.11",
+ "penumbra-sdk-num 2.0.0-alpha.11",
+ "penumbra-sdk-proof-params 2.0.0-alpha.11",
+ "penumbra-sdk-proto 2.0.0-alpha.11",
+ "penumbra-sdk-sct 2.0.0-alpha.11",
+ "penumbra-sdk-shielded-pool 2.0.0-alpha.11",
+ "penumbra-sdk-stake 2.0.0-alpha.11",
+ "penumbra-sdk-tct 2.0.0-alpha.11",
+ "penumbra-sdk-txhash 2.0.0-alpha.11",
  "poseidon377",
  "rand 0.8.5",
  "rand_core 0.6.4",
@@ -8766,29 +8770,29 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-txhash"
-version = "1.5.1"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v1.5.1#d55e7e80eb42ecb205d88d270644c3e23e2cde36"
+version = "1.5.2"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v1.5.2#07c4ba1381fa76b47878dc231f616ae441266976"
 dependencies = [
  "anyhow",
  "blake2b_simd 1.0.3",
  "getrandom 0.2.16",
  "hex",
- "penumbra-sdk-proto 1.5.1",
- "penumbra-sdk-tct 1.5.1",
+ "penumbra-sdk-proto 1.5.2",
+ "penumbra-sdk-tct 1.5.2",
  "serde",
 ]
 
 [[package]]
 name = "penumbra-sdk-txhash"
-version = "2.0.0-alpha.10"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.10#c209a52ea26efc5a2f02df0105405e93917fa5c4"
+version = "2.0.0-alpha.11"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
 dependencies = [
  "anyhow",
  "blake2b_simd 1.0.3",
  "getrandom 0.2.16",
  "hex",
- "penumbra-sdk-proto 2.0.0-alpha.10",
- "penumbra-sdk-tct 2.0.0-alpha.10",
+ "penumbra-sdk-proto 2.0.0-alpha.11",
+ "penumbra-sdk-tct 2.0.0-alpha.11",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,20 +60,20 @@ penumbra-sdk-sct-v1o3 = { package = "penumbra-sdk-sct", tag = "v1.3.2", git = "h
 penumbra-sdk-transaction-v1o3 = { package = "penumbra-sdk-transaction", tag = "v1.3.2", git = "https://github.com/penumbra-zone/penumbra" }
 
 # v1.4.x dependencies; APP_VERSION 10
-penumbra-sdk-app-v1o4 = { package = "penumbra-sdk-app", tag = "v1.5.1", git = "https://github.com/penumbra-zone/penumbra" }
-penumbra-sdk-governance-v1o4 = { package = "penumbra-sdk-governance", tag = "v1.5.1", git = "https://github.com/penumbra-zone/penumbra" }
-penumbra-sdk-ibc-v1o4 = { package = "penumbra-sdk-ibc", tag = "v1.5.1", git = "https://github.com/penumbra-zone/penumbra" }
-penumbra-sdk-sct-v1o4 = { package = "penumbra-sdk-sct", tag = "v1.5.1", git = "https://github.com/penumbra-zone/penumbra" }
-penumbra-sdk-transaction-v1o4 = { package = "penumbra-sdk-transaction", tag = "v1.5.1", git = "https://github.com/penumbra-zone/penumbra" }
+penumbra-sdk-app-v1o4 = { package = "penumbra-sdk-app", tag = "v1.5.2", git = "https://github.com/penumbra-zone/penumbra" }
+penumbra-sdk-governance-v1o4 = { package = "penumbra-sdk-governance", tag = "v1.5.2", git = "https://github.com/penumbra-zone/penumbra" }
+penumbra-sdk-ibc-v1o4 = { package = "penumbra-sdk-ibc", tag = "v1.5.2", git = "https://github.com/penumbra-zone/penumbra" }
+penumbra-sdk-sct-v1o4 = { package = "penumbra-sdk-sct", tag = "v1.5.2", git = "https://github.com/penumbra-zone/penumbra" }
+penumbra-sdk-transaction-v1o4 = { package = "penumbra-sdk-transaction", tag = "v1.5.2", git = "https://github.com/penumbra-zone/penumbra" }
 
 # v2.x dependencies; APP_VERSION 10
 # This still depends on cnidarium at version 0.83.0, and cargo will complain
 # if we try and add it as a dependency.
-penumbra-sdk-app-v2 = { package = "penumbra-sdk-app", git = "https://github.com/penumbra-zone/penumbra", tag = "v2.0.0-alpha.10"}
-penumbra-sdk-governance-v2 = { package = "penumbra-sdk-governance", git = "https://github.com/penumbra-zone/penumbra", tag = "v2.0.0-alpha.10"}
-penumbra-sdk-ibc-v2 = { package = "penumbra-sdk-ibc", git = "https://github.com/penumbra-zone/penumbra", tag = "v2.0.0-alpha.10"}
-penumbra-sdk-sct-v2 = { package = "penumbra-sdk-sct", git = "https://github.com/penumbra-zone/penumbra", tag = "v2.0.0-alpha.10"}
-penumbra-sdk-transaction-v2 = { package = "penumbra-sdk-transaction", git = "https://github.com/penumbra-zone/penumbra", tag = "v2.0.0-alpha.10"}
+penumbra-sdk-app-v2 = { package = "penumbra-sdk-app", git = "https://github.com/penumbra-zone/penumbra", tag = "v2.0.0-alpha.11"}
+penumbra-sdk-governance-v2 = { package = "penumbra-sdk-governance", git = "https://github.com/penumbra-zone/penumbra", tag = "v2.0.0-alpha.11"}
+penumbra-sdk-ibc-v2 = { package = "penumbra-sdk-ibc", git = "https://github.com/penumbra-zone/penumbra", tag = "v2.0.0-alpha.11"}
+penumbra-sdk-sct-v2 = { package = "penumbra-sdk-sct", git = "https://github.com/penumbra-zone/penumbra", tag = "v2.0.0-alpha.11"}
+penumbra-sdk-transaction-v2 = { package = "penumbra-sdk-transaction", git = "https://github.com/penumbra-zone/penumbra", tag = "v2.0.0-alpha.11"}
 
 sha2 = { version = "0.10.8", default-features = false }
 digest = { version = "0.10.7", default-features = false }


### PR DESCRIPTION
Bumps the testnet/LQT deps to v2.0.0-alpha.11 [0]. Bumps the mainnet/v1 deps to v1.5.2 [1].

[0] https://github.com/penumbra-zone/penumbra/issues/5010
[1] https://github.com/penumbra-zone/penumbra/issues/5203