### PR TITLE
feat: support penumbra v2 on penumbra-1 chain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1221,8 +1221,8 @@ dependencies = [
 
 [[package]]
 name = "cnidarium-component"
-version = "2.0.0-alpha.12"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.12#ab93b98ab0616b3f03b279c650dbdb73636f3a80"
+version = "2.0.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0#f0d75958d44c9e946102731e3ace3ac51f5cccc8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1564,8 +1564,8 @@ dependencies = [
 
 [[package]]
 name = "decaf377-fmd"
-version = "2.0.0-alpha.12"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.12#ab93b98ab0616b3f03b279c650dbdb73636f3a80"
+version = "2.0.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0#f0d75958d44c9e946102731e3ace3ac51f5cccc8"
 dependencies = [
  "ark-ff",
  "ark-serialize",
@@ -1648,8 +1648,8 @@ dependencies = [
 
 [[package]]
 name = "decaf377-ka"
-version = "2.0.0-alpha.12"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.12#ab93b98ab0616b3f03b279c650dbdb73636f3a80"
+version = "2.0.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0#f0d75958d44c9e946102731e3ace3ac51f5cccc8"
 dependencies = [
  "ark-ff",
  "decaf377",
@@ -6112,19 +6112,19 @@ dependencies = [
  "penumbra-sct 0.81.3",
  "penumbra-sdk-app 1.3.2",
  "penumbra-sdk-app 1.5.3",
- "penumbra-sdk-app 2.0.0-alpha.12",
+ "penumbra-sdk-app 2.0.0",
  "penumbra-sdk-governance 1.3.2",
  "penumbra-sdk-governance 1.5.3",
- "penumbra-sdk-governance 2.0.0-alpha.12",
+ "penumbra-sdk-governance 2.0.0",
  "penumbra-sdk-ibc 1.3.2",
  "penumbra-sdk-ibc 1.5.3",
- "penumbra-sdk-ibc 2.0.0-alpha.12",
+ "penumbra-sdk-ibc 2.0.0",
  "penumbra-sdk-sct 1.3.2",
  "penumbra-sdk-sct 1.5.3",
- "penumbra-sdk-sct 2.0.0-alpha.12",
+ "penumbra-sdk-sct 2.0.0",
  "penumbra-sdk-transaction 1.3.2",
  "penumbra-sdk-transaction 1.5.3",
- "penumbra-sdk-transaction 2.0.0-alpha.12",
+ "penumbra-sdk-transaction 2.0.0",
  "penumbra-transaction 0.80.13",
  "penumbra-transaction 0.81.3",
  "prost 0.13.5",
@@ -6402,8 +6402,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-app"
-version = "2.0.0-alpha.12"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.12#ab93b98ab0616b3f03b279c650dbdb73636f3a80"
+version = "2.0.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0#f0d75958d44c9e946102731e3ace3ac51f5cccc8"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -6415,7 +6415,7 @@ dependencies = [
  "blake2b_simd 1.0.3",
  "cfg-if",
  "cnidarium 0.83.0",
- "cnidarium-component 2.0.0-alpha.12",
+ "cnidarium-component 2.0.0",
  "decaf377",
  "decaf377-rdsa",
  "futures",
@@ -6428,27 +6428,27 @@ dependencies = [
  "metrics 0.24.2",
  "once_cell",
  "parking_lot",
- "penumbra-sdk-asset 2.0.0-alpha.12",
- "penumbra-sdk-auction 2.0.0-alpha.12",
- "penumbra-sdk-community-pool 2.0.0-alpha.12",
- "penumbra-sdk-compact-block 2.0.0-alpha.12",
- "penumbra-sdk-dex 2.0.0-alpha.12",
- "penumbra-sdk-distributions 2.0.0-alpha.12",
- "penumbra-sdk-fee 2.0.0-alpha.12",
- "penumbra-sdk-funding 2.0.0-alpha.12",
- "penumbra-sdk-governance 2.0.0-alpha.12",
- "penumbra-sdk-ibc 2.0.0-alpha.12",
- "penumbra-sdk-keys 2.0.0-alpha.12",
- "penumbra-sdk-num 2.0.0-alpha.12",
- "penumbra-sdk-proof-params 2.0.0-alpha.12",
- "penumbra-sdk-proto 2.0.0-alpha.12",
- "penumbra-sdk-sct 2.0.0-alpha.12",
- "penumbra-sdk-shielded-pool 2.0.0-alpha.12",
- "penumbra-sdk-stake 2.0.0-alpha.12",
- "penumbra-sdk-tct 2.0.0-alpha.12",
- "penumbra-sdk-tower-trace 2.0.0-alpha.12",
- "penumbra-sdk-transaction 2.0.0-alpha.12",
- "penumbra-sdk-txhash 2.0.0-alpha.12",
+ "penumbra-sdk-asset 2.0.0",
+ "penumbra-sdk-auction 2.0.0",
+ "penumbra-sdk-community-pool 2.0.0",
+ "penumbra-sdk-compact-block 2.0.0",
+ "penumbra-sdk-dex 2.0.0",
+ "penumbra-sdk-distributions 2.0.0",
+ "penumbra-sdk-fee 2.0.0",
+ "penumbra-sdk-funding 2.0.0",
+ "penumbra-sdk-governance 2.0.0",
+ "penumbra-sdk-ibc 2.0.0",
+ "penumbra-sdk-keys 2.0.0",
+ "penumbra-sdk-num 2.0.0",
+ "penumbra-sdk-proof-params 2.0.0",
+ "penumbra-sdk-proto 2.0.0",
+ "penumbra-sdk-sct 2.0.0",
+ "penumbra-sdk-shielded-pool 2.0.0",
+ "penumbra-sdk-stake 2.0.0",
+ "penumbra-sdk-tct 2.0.0",
+ "penumbra-sdk-tower-trace 2.0.0",
+ "penumbra-sdk-transaction 2.0.0",
+ "penumbra-sdk-txhash 2.0.0",
  "prost 0.13.5",
  "rand_chacha 0.3.1",
  "regex",
@@ -6555,8 +6555,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-asset"
-version = "2.0.0-alpha.12"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.12#ab93b98ab0616b3f03b279c650dbdb73636f3a80"
+version = "2.0.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0#f0d75958d44c9e946102731e3ace3ac51f5cccc8"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -6569,7 +6569,7 @@ dependencies = [
  "blake2b_simd 1.0.3",
  "bytes",
  "decaf377",
- "decaf377-fmd 2.0.0-alpha.12",
+ "decaf377-fmd 2.0.0",
  "decaf377-rdsa",
  "derivative",
  "ethnum",
@@ -6580,8 +6580,8 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "pbjson-types 0.7.0",
- "penumbra-sdk-num 2.0.0-alpha.12",
- "penumbra-sdk-proto 2.0.0-alpha.12",
+ "penumbra-sdk-num 2.0.0",
+ "penumbra-sdk-proto 2.0.0",
  "poseidon377",
  "rand 0.8.5",
  "rand_core 0.6.4",
@@ -6699,8 +6699,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-auction"
-version = "2.0.0-alpha.12"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.12#ab93b98ab0616b3f03b279c650dbdb73636f3a80"
+version = "2.0.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0#f0d75958d44c9e946102731e3ace3ac51f5cccc8"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -6716,7 +6716,7 @@ dependencies = [
  "bitvec",
  "blake2b_simd 1.0.3",
  "cnidarium 0.83.0",
- "cnidarium-component 2.0.0-alpha.12",
+ "cnidarium-component 2.0.0",
  "decaf377",
  "decaf377-rdsa",
  "futures",
@@ -6724,16 +6724,16 @@ dependencies = [
  "metrics 0.24.2",
  "once_cell",
  "pbjson-types 0.7.0",
- "penumbra-sdk-asset 2.0.0-alpha.12",
- "penumbra-sdk-dex 2.0.0-alpha.12",
- "penumbra-sdk-keys 2.0.0-alpha.12",
- "penumbra-sdk-num 2.0.0-alpha.12",
- "penumbra-sdk-proof-params 2.0.0-alpha.12",
- "penumbra-sdk-proto 2.0.0-alpha.12",
- "penumbra-sdk-sct 2.0.0-alpha.12",
- "penumbra-sdk-shielded-pool 2.0.0-alpha.12",
- "penumbra-sdk-tct 2.0.0-alpha.12",
- "penumbra-sdk-txhash 2.0.0-alpha.12",
+ "penumbra-sdk-asset 2.0.0",
+ "penumbra-sdk-dex 2.0.0",
+ "penumbra-sdk-keys 2.0.0",
+ "penumbra-sdk-num 2.0.0",
+ "penumbra-sdk-proof-params 2.0.0",
+ "penumbra-sdk-proto 2.0.0",
+ "penumbra-sdk-sct 2.0.0",
+ "penumbra-sdk-shielded-pool 2.0.0",
+ "penumbra-sdk-tct 2.0.0",
+ "penumbra-sdk-txhash 2.0.0",
  "prost 0.13.5",
  "prost-types 0.13.5",
  "rand_chacha 0.3.1",
@@ -6817,8 +6817,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-community-pool"
-version = "2.0.0-alpha.12"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.12#ab93b98ab0616b3f03b279c650dbdb73636f3a80"
+version = "2.0.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0#f0d75958d44c9e946102731e3ace3ac51f5cccc8"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -6827,19 +6827,19 @@ dependencies = [
  "base64 0.21.7",
  "blake2b_simd 1.0.3",
  "cnidarium 0.83.0",
- "cnidarium-component 2.0.0-alpha.12",
+ "cnidarium-component 2.0.0",
  "futures",
  "hex",
  "metrics 0.24.2",
  "once_cell",
  "pbjson-types 0.7.0",
- "penumbra-sdk-asset 2.0.0-alpha.12",
- "penumbra-sdk-keys 2.0.0-alpha.12",
- "penumbra-sdk-num 2.0.0-alpha.12",
- "penumbra-sdk-proto 2.0.0-alpha.12",
- "penumbra-sdk-sct 2.0.0-alpha.12",
- "penumbra-sdk-shielded-pool 2.0.0-alpha.12",
- "penumbra-sdk-txhash 2.0.0-alpha.12",
+ "penumbra-sdk-asset 2.0.0",
+ "penumbra-sdk-keys 2.0.0",
+ "penumbra-sdk-num 2.0.0",
+ "penumbra-sdk-proto 2.0.0",
+ "penumbra-sdk-sct 2.0.0",
+ "penumbra-sdk-shielded-pool 2.0.0",
+ "penumbra-sdk-txhash 2.0.0",
  "prost 0.13.5",
  "serde",
  "sha2 0.10.9",
@@ -6923,8 +6923,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-compact-block"
-version = "2.0.0-alpha.12"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.12#ab93b98ab0616b3f03b279c650dbdb73636f3a80"
+version = "2.0.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0#f0d75958d44c9e946102731e3ace3ac51f5cccc8"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -6932,21 +6932,21 @@ dependencies = [
  "blake2b_simd 1.0.3",
  "bytes",
  "cnidarium 0.83.0",
- "cnidarium-component 2.0.0-alpha.12",
+ "cnidarium-component 2.0.0",
  "decaf377-rdsa",
  "futures",
  "im",
  "metrics 0.24.2",
- "penumbra-sdk-dex 2.0.0-alpha.12",
- "penumbra-sdk-fee 2.0.0-alpha.12",
- "penumbra-sdk-governance 2.0.0-alpha.12",
- "penumbra-sdk-ibc 2.0.0-alpha.12",
- "penumbra-sdk-proof-params 2.0.0-alpha.12",
- "penumbra-sdk-proto 2.0.0-alpha.12",
- "penumbra-sdk-sct 2.0.0-alpha.12",
- "penumbra-sdk-shielded-pool 2.0.0-alpha.12",
- "penumbra-sdk-stake 2.0.0-alpha.12",
- "penumbra-sdk-tct 2.0.0-alpha.12",
+ "penumbra-sdk-dex 2.0.0",
+ "penumbra-sdk-fee 2.0.0",
+ "penumbra-sdk-governance 2.0.0",
+ "penumbra-sdk-ibc 2.0.0",
+ "penumbra-sdk-proof-params 2.0.0",
+ "penumbra-sdk-proto 2.0.0",
+ "penumbra-sdk-sct 2.0.0",
+ "penumbra-sdk-shielded-pool 2.0.0",
+ "penumbra-sdk-stake 2.0.0",
+ "penumbra-sdk-tct 2.0.0",
  "rand 0.8.5",
  "rand_core 0.6.4",
  "serde",
@@ -7075,8 +7075,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-dex"
-version = "2.0.0-alpha.12"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.12#ab93b98ab0616b3f03b279c650dbdb73636f3a80"
+version = "2.0.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0#f0d75958d44c9e946102731e3ace3ac51f5cccc8"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -7092,10 +7092,10 @@ dependencies = [
  "blake2b_simd 1.0.3",
  "chacha20poly1305",
  "cnidarium 0.83.0",
- "cnidarium-component 2.0.0-alpha.12",
+ "cnidarium-component 2.0.0",
  "decaf377",
- "decaf377-fmd 2.0.0-alpha.12",
- "decaf377-ka 2.0.0-alpha.12",
+ "decaf377-fmd 2.0.0",
+ "decaf377-ka 2.0.0",
  "decaf377-rdsa",
  "futures",
  "hex",
@@ -7105,16 +7105,16 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "pbjson-types 0.7.0",
- "penumbra-sdk-asset 2.0.0-alpha.12",
- "penumbra-sdk-fee 2.0.0-alpha.12",
- "penumbra-sdk-keys 2.0.0-alpha.12",
- "penumbra-sdk-num 2.0.0-alpha.12",
- "penumbra-sdk-proof-params 2.0.0-alpha.12",
- "penumbra-sdk-proto 2.0.0-alpha.12",
- "penumbra-sdk-sct 2.0.0-alpha.12",
- "penumbra-sdk-shielded-pool 2.0.0-alpha.12",
- "penumbra-sdk-tct 2.0.0-alpha.12",
- "penumbra-sdk-txhash 2.0.0-alpha.12",
+ "penumbra-sdk-asset 2.0.0",
+ "penumbra-sdk-fee 2.0.0",
+ "penumbra-sdk-keys 2.0.0",
+ "penumbra-sdk-num 2.0.0",
+ "penumbra-sdk-proof-params 2.0.0",
+ "penumbra-sdk-proto 2.0.0",
+ "penumbra-sdk-sct 2.0.0",
+ "penumbra-sdk-shielded-pool 2.0.0",
+ "penumbra-sdk-tct 2.0.0",
+ "penumbra-sdk-txhash 2.0.0",
  "poseidon377",
  "prost 0.13.5",
  "rand_core 0.6.4",
@@ -7170,17 +7170,17 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-distributions"
-version = "2.0.0-alpha.12"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.12#ab93b98ab0616b3f03b279c650dbdb73636f3a80"
+version = "2.0.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0#f0d75958d44c9e946102731e3ace3ac51f5cccc8"
 dependencies = [
  "anyhow",
  "async-trait",
  "cnidarium 0.83.0",
- "cnidarium-component 2.0.0-alpha.12",
- "penumbra-sdk-asset 2.0.0-alpha.12",
- "penumbra-sdk-num 2.0.0-alpha.12",
- "penumbra-sdk-proto 2.0.0-alpha.12",
- "penumbra-sdk-sct 2.0.0-alpha.12",
+ "cnidarium-component 2.0.0",
+ "penumbra-sdk-asset 2.0.0",
+ "penumbra-sdk-num 2.0.0",
+ "penumbra-sdk-proto 2.0.0",
+ "penumbra-sdk-sct 2.0.0",
  "serde",
  "tendermint 0.40.3",
  "tonic 0.12.3",
@@ -7243,8 +7243,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-fee"
-version = "2.0.0-alpha.12"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.12#ab93b98ab0616b3f03b279c650dbdb73636f3a80"
+version = "2.0.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0#f0d75958d44c9e946102731e3ace3ac51f5cccc8"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -7252,14 +7252,14 @@ dependencies = [
  "blake2b_simd 1.0.3",
  "bytes",
  "cnidarium 0.83.0",
- "cnidarium-component 2.0.0-alpha.12",
+ "cnidarium-component 2.0.0",
  "decaf377",
  "decaf377-rdsa",
  "im",
  "metrics 0.24.2",
- "penumbra-sdk-asset 2.0.0-alpha.12",
- "penumbra-sdk-num 2.0.0-alpha.12",
- "penumbra-sdk-proto 2.0.0-alpha.12",
+ "penumbra-sdk-asset 2.0.0",
+ "penumbra-sdk-num 2.0.0",
+ "penumbra-sdk-proto 2.0.0",
  "rand 0.8.5",
  "rand_core 0.6.4",
  "serde",
@@ -7318,33 +7318,33 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-funding"
-version = "2.0.0-alpha.12"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.12#ab93b98ab0616b3f03b279c650dbdb73636f3a80"
+version = "2.0.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0#f0d75958d44c9e946102731e3ace3ac51f5cccc8"
 dependencies = [
  "anyhow",
  "ark-groth16",
  "async-trait",
  "base64 0.21.7",
  "cnidarium 0.83.0",
- "cnidarium-component 2.0.0-alpha.12",
+ "cnidarium-component 2.0.0",
  "decaf377",
  "decaf377-rdsa",
  "futures",
  "metrics 0.24.2",
- "penumbra-sdk-asset 2.0.0-alpha.12",
- "penumbra-sdk-community-pool 2.0.0-alpha.12",
- "penumbra-sdk-dex 2.0.0-alpha.12",
- "penumbra-sdk-distributions 2.0.0-alpha.12",
- "penumbra-sdk-governance 2.0.0-alpha.12",
- "penumbra-sdk-keys 2.0.0-alpha.12",
- "penumbra-sdk-num 2.0.0-alpha.12",
- "penumbra-sdk-proof-params 2.0.0-alpha.12",
- "penumbra-sdk-proto 2.0.0-alpha.12",
- "penumbra-sdk-sct 2.0.0-alpha.12",
- "penumbra-sdk-shielded-pool 2.0.0-alpha.12",
- "penumbra-sdk-stake 2.0.0-alpha.12",
- "penumbra-sdk-tct 2.0.0-alpha.12",
- "penumbra-sdk-txhash 2.0.0-alpha.12",
+ "penumbra-sdk-asset 2.0.0",
+ "penumbra-sdk-community-pool 2.0.0",
+ "penumbra-sdk-dex 2.0.0",
+ "penumbra-sdk-distributions 2.0.0",
+ "penumbra-sdk-governance 2.0.0",
+ "penumbra-sdk-keys 2.0.0",
+ "penumbra-sdk-num 2.0.0",
+ "penumbra-sdk-proof-params 2.0.0",
+ "penumbra-sdk-proto 2.0.0",
+ "penumbra-sdk-sct 2.0.0",
+ "penumbra-sdk-shielded-pool 2.0.0",
+ "penumbra-sdk-stake 2.0.0",
+ "penumbra-sdk-tct 2.0.0",
+ "penumbra-sdk-txhash 2.0.0",
  "rand 0.8.5",
  "serde",
  "tendermint 0.40.3",
@@ -7460,8 +7460,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-governance"
-version = "2.0.0-alpha.12"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.12#ab93b98ab0616b3f03b279c650dbdb73636f3a80"
+version = "2.0.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0#f0d75958d44c9e946102731e3ace3ac51f5cccc8"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -7476,7 +7476,7 @@ dependencies = [
  "blake2b_simd 1.0.3",
  "bytes",
  "cnidarium 0.83.0",
- "cnidarium-component 2.0.0-alpha.12",
+ "cnidarium-component 2.0.0",
  "decaf377",
  "decaf377-rdsa",
  "futures",
@@ -7485,18 +7485,18 @@ dependencies = [
  "metrics 0.24.2",
  "once_cell",
  "pbjson-types 0.7.0",
- "penumbra-sdk-asset 2.0.0-alpha.12",
- "penumbra-sdk-distributions 2.0.0-alpha.12",
- "penumbra-sdk-ibc 2.0.0-alpha.12",
- "penumbra-sdk-keys 2.0.0-alpha.12",
- "penumbra-sdk-num 2.0.0-alpha.12",
- "penumbra-sdk-proof-params 2.0.0-alpha.12",
- "penumbra-sdk-proto 2.0.0-alpha.12",
- "penumbra-sdk-sct 2.0.0-alpha.12",
- "penumbra-sdk-shielded-pool 2.0.0-alpha.12",
- "penumbra-sdk-stake 2.0.0-alpha.12",
- "penumbra-sdk-tct 2.0.0-alpha.12",
- "penumbra-sdk-txhash 2.0.0-alpha.12",
+ "penumbra-sdk-asset 2.0.0",
+ "penumbra-sdk-distributions 2.0.0",
+ "penumbra-sdk-ibc 2.0.0",
+ "penumbra-sdk-keys 2.0.0",
+ "penumbra-sdk-num 2.0.0",
+ "penumbra-sdk-proof-params 2.0.0",
+ "penumbra-sdk-proto 2.0.0",
+ "penumbra-sdk-sct 2.0.0",
+ "penumbra-sdk-shielded-pool 2.0.0",
+ "penumbra-sdk-stake 2.0.0",
+ "penumbra-sdk-tct 2.0.0",
+ "penumbra-sdk-txhash 2.0.0",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
@@ -7587,8 +7587,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-ibc"
-version = "2.0.0-alpha.12"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.12#ab93b98ab0616b3f03b279c650dbdb73636f3a80"
+version = "2.0.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0#f0d75958d44c9e946102731e3ace3ac51f5cccc8"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -7605,11 +7605,11 @@ dependencies = [
  "num-traits",
  "once_cell",
  "pbjson-types 0.7.0",
- "penumbra-sdk-asset 2.0.0-alpha.12",
- "penumbra-sdk-num 2.0.0-alpha.12",
- "penumbra-sdk-proto 2.0.0-alpha.12",
- "penumbra-sdk-sct 2.0.0-alpha.12",
- "penumbra-sdk-txhash 2.0.0-alpha.12",
+ "penumbra-sdk-asset 2.0.0",
+ "penumbra-sdk-num 2.0.0",
+ "penumbra-sdk-proto 2.0.0",
+ "penumbra-sdk-sct 2.0.0",
+ "penumbra-sdk-txhash 2.0.0",
  "prost 0.13.5",
  "serde",
  "serde_json",
@@ -7712,8 +7712,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-keys"
-version = "2.0.0-alpha.12"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.12#ab93b98ab0616b3f03b279c650dbdb73636f3a80"
+version = "2.0.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0#f0d75958d44c9e946102731e3ace3ac51f5cccc8"
 dependencies = [
  "aes",
  "anyhow",
@@ -7729,8 +7729,8 @@ dependencies = [
  "bytes",
  "chacha20poly1305",
  "decaf377",
- "decaf377-fmd 2.0.0-alpha.12",
- "decaf377-ka 2.0.0-alpha.12",
+ "decaf377-fmd 2.0.0",
+ "decaf377-ka 2.0.0",
  "decaf377-rdsa",
  "derivative",
  "ethnum",
@@ -7741,9 +7741,9 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "pbkdf2",
- "penumbra-sdk-asset 2.0.0-alpha.12",
- "penumbra-sdk-proto 2.0.0-alpha.12",
- "penumbra-sdk-tct 2.0.0-alpha.12",
+ "penumbra-sdk-asset 2.0.0",
+ "penumbra-sdk-proto 2.0.0",
+ "penumbra-sdk-tct 2.0.0",
  "poseidon377",
  "rand 0.8.5",
  "rand_core 0.6.4",
@@ -7828,8 +7828,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-num"
-version = "2.0.0-alpha.12"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.12#ab93b98ab0616b3f03b279c650dbdb73636f3a80"
+version = "2.0.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0#f0d75958d44c9e946102731e3ace3ac51f5cccc8"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -7844,7 +7844,7 @@ dependencies = [
  "blake2b_simd 1.0.3",
  "bytes",
  "decaf377",
- "decaf377-fmd 2.0.0-alpha.12",
+ "decaf377-fmd 2.0.0",
  "decaf377-rdsa",
  "derivative",
  "ethnum",
@@ -7852,7 +7852,7 @@ dependencies = [
  "ibig",
  "num-bigint",
  "once_cell",
- "penumbra-sdk-proto 2.0.0-alpha.12",
+ "penumbra-sdk-proto 2.0.0",
  "rand 0.8.5",
  "rand_core 0.6.4",
  "regex",
@@ -7914,8 +7914,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-proof-params"
-version = "2.0.0-alpha.12"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.12#ab93b98ab0616b3f03b279c650dbdb73636f3a80"
+version = "2.0.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0#f0d75958d44c9e946102731e3ace3ac51f5cccc8"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -7997,15 +7997,15 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-proto"
-version = "2.0.0-alpha.12"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.12#ab93b98ab0616b3f03b279c650dbdb73636f3a80"
+version = "2.0.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0#f0d75958d44c9e946102731e3ace3ac51f5cccc8"
 dependencies = [
  "anyhow",
  "async-trait",
  "bech32",
  "bytes",
  "cnidarium 0.83.0",
- "decaf377-fmd 2.0.0-alpha.12",
+ "decaf377-fmd 2.0.0",
  "decaf377-rdsa",
  "futures",
  "hex",
@@ -8098,8 +8098,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-sct"
-version = "2.0.0-alpha.12"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.12#ab93b98ab0616b3f03b279c650dbdb73636f3a80"
+version = "2.0.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0#f0d75958d44c9e946102731e3ace3ac51f5cccc8"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -8112,7 +8112,7 @@ dependencies = [
  "bytes",
  "chrono",
  "cnidarium 0.83.0",
- "cnidarium-component 2.0.0-alpha.12",
+ "cnidarium-component 2.0.0",
  "decaf377",
  "decaf377-rdsa",
  "hex",
@@ -8120,10 +8120,10 @@ dependencies = [
  "metrics 0.24.2",
  "once_cell",
  "pbjson-types 0.7.0",
- "penumbra-sdk-keys 2.0.0-alpha.12",
- "penumbra-sdk-proto 2.0.0-alpha.12",
- "penumbra-sdk-tct 2.0.0-alpha.12",
- "penumbra-sdk-txhash 2.0.0-alpha.12",
+ "penumbra-sdk-keys 2.0.0",
+ "penumbra-sdk-proto 2.0.0",
+ "penumbra-sdk-tct 2.0.0",
+ "penumbra-sdk-txhash 2.0.0",
  "poseidon377",
  "rand 0.8.5",
  "rand_core 0.6.4",
@@ -8243,8 +8243,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-shielded-pool"
-version = "2.0.0-alpha.12"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.12#ab93b98ab0616b3f03b279c650dbdb73636f3a80"
+version = "2.0.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0#f0d75958d44c9e946102731e3ace3ac51f5cccc8"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -8260,10 +8260,10 @@ dependencies = [
  "bytes",
  "chacha20poly1305",
  "cnidarium 0.83.0",
- "cnidarium-component 2.0.0-alpha.12",
+ "cnidarium-component 2.0.0",
  "decaf377",
- "decaf377-fmd 2.0.0-alpha.12",
- "decaf377-ka 2.0.0-alpha.12",
+ "decaf377-fmd 2.0.0",
+ "decaf377-ka 2.0.0",
  "decaf377-rdsa",
  "futures",
  "hex",
@@ -8272,15 +8272,15 @@ dependencies = [
  "im",
  "metrics 0.24.2",
  "once_cell",
- "penumbra-sdk-asset 2.0.0-alpha.12",
- "penumbra-sdk-ibc 2.0.0-alpha.12",
- "penumbra-sdk-keys 2.0.0-alpha.12",
- "penumbra-sdk-num 2.0.0-alpha.12",
- "penumbra-sdk-proof-params 2.0.0-alpha.12",
- "penumbra-sdk-proto 2.0.0-alpha.12",
- "penumbra-sdk-sct 2.0.0-alpha.12",
- "penumbra-sdk-tct 2.0.0-alpha.12",
- "penumbra-sdk-txhash 2.0.0-alpha.12",
+ "penumbra-sdk-asset 2.0.0",
+ "penumbra-sdk-ibc 2.0.0",
+ "penumbra-sdk-keys 2.0.0",
+ "penumbra-sdk-num 2.0.0",
+ "penumbra-sdk-proof-params 2.0.0",
+ "penumbra-sdk-proto 2.0.0",
+ "penumbra-sdk-sct 2.0.0",
+ "penumbra-sdk-tct 2.0.0",
+ "penumbra-sdk-txhash 2.0.0",
  "poseidon377",
  "prost 0.13.5",
  "rand 0.8.5",
@@ -8397,8 +8397,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-stake"
-version = "2.0.0-alpha.12"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.12#ab93b98ab0616b3f03b279c650dbdb73636f3a80"
+version = "2.0.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0#f0d75958d44c9e946102731e3ace3ac51f5cccc8"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -8413,7 +8413,7 @@ dependencies = [
  "bech32",
  "bitvec",
  "cnidarium 0.83.0",
- "cnidarium-component 2.0.0-alpha.12",
+ "cnidarium-component 2.0.0",
  "decaf377",
  "decaf377-rdsa",
  "futures",
@@ -8421,16 +8421,16 @@ dependencies = [
  "im",
  "metrics 0.24.2",
  "once_cell",
- "penumbra-sdk-asset 2.0.0-alpha.12",
- "penumbra-sdk-distributions 2.0.0-alpha.12",
- "penumbra-sdk-keys 2.0.0-alpha.12",
- "penumbra-sdk-num 2.0.0-alpha.12",
- "penumbra-sdk-proof-params 2.0.0-alpha.12",
- "penumbra-sdk-proto 2.0.0-alpha.12",
- "penumbra-sdk-sct 2.0.0-alpha.12",
- "penumbra-sdk-shielded-pool 2.0.0-alpha.12",
- "penumbra-sdk-tct 2.0.0-alpha.12",
- "penumbra-sdk-txhash 2.0.0-alpha.12",
+ "penumbra-sdk-asset 2.0.0",
+ "penumbra-sdk-distributions 2.0.0",
+ "penumbra-sdk-keys 2.0.0",
+ "penumbra-sdk-num 2.0.0",
+ "penumbra-sdk-proof-params 2.0.0",
+ "penumbra-sdk-proto 2.0.0",
+ "penumbra-sdk-sct 2.0.0",
+ "penumbra-sdk-shielded-pool 2.0.0",
+ "penumbra-sdk-tct 2.0.0",
+ "penumbra-sdk-txhash 2.0.0",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "regex",
@@ -8505,8 +8505,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-tct"
-version = "2.0.0-alpha.12"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.12#ab93b98ab0616b3f03b279c650dbdb73636f3a80"
+version = "2.0.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0#f0d75958d44c9e946102731e3ace3ac51f5cccc8"
 dependencies = [
  "ark-ed-on-bls12-377",
  "ark-ff",
@@ -8524,7 +8524,7 @@ dependencies = [
  "im",
  "once_cell",
  "parking_lot",
- "penumbra-sdk-proto 2.0.0-alpha.12",
+ "penumbra-sdk-proto 2.0.0",
  "poseidon377",
  "rand 0.8.5",
  "serde",
@@ -8578,8 +8578,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-tower-trace"
-version = "2.0.0-alpha.12"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.12#ab93b98ab0616b3f03b279c650dbdb73636f3a80"
+version = "2.0.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0#f0d75958d44c9e946102731e3ace3ac51f5cccc8"
 dependencies = [
  "futures",
  "hex",
@@ -8704,8 +8704,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-transaction"
-version = "2.0.0-alpha.12"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.12#ab93b98ab0616b3f03b279c650dbdb73636f3a80"
+version = "2.0.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0#f0d75958d44c9e946102731e3ace3ac51f5cccc8"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -8716,8 +8716,8 @@ dependencies = [
  "bytes",
  "chacha20poly1305",
  "decaf377",
- "decaf377-fmd 2.0.0-alpha.12",
- "decaf377-ka 2.0.0-alpha.12",
+ "decaf377-fmd 2.0.0",
+ "decaf377-ka 2.0.0",
  "decaf377-rdsa",
  "derivative",
  "hex",
@@ -8726,23 +8726,23 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "pbjson-types 0.7.0",
- "penumbra-sdk-asset 2.0.0-alpha.12",
- "penumbra-sdk-auction 2.0.0-alpha.12",
- "penumbra-sdk-community-pool 2.0.0-alpha.12",
- "penumbra-sdk-dex 2.0.0-alpha.12",
- "penumbra-sdk-fee 2.0.0-alpha.12",
- "penumbra-sdk-funding 2.0.0-alpha.12",
- "penumbra-sdk-governance 2.0.0-alpha.12",
- "penumbra-sdk-ibc 2.0.0-alpha.12",
- "penumbra-sdk-keys 2.0.0-alpha.12",
- "penumbra-sdk-num 2.0.0-alpha.12",
- "penumbra-sdk-proof-params 2.0.0-alpha.12",
- "penumbra-sdk-proto 2.0.0-alpha.12",
- "penumbra-sdk-sct 2.0.0-alpha.12",
- "penumbra-sdk-shielded-pool 2.0.0-alpha.12",
- "penumbra-sdk-stake 2.0.0-alpha.12",
- "penumbra-sdk-tct 2.0.0-alpha.12",
- "penumbra-sdk-txhash 2.0.0-alpha.12",
+ "penumbra-sdk-asset 2.0.0",
+ "penumbra-sdk-auction 2.0.0",
+ "penumbra-sdk-community-pool 2.0.0",
+ "penumbra-sdk-dex 2.0.0",
+ "penumbra-sdk-fee 2.0.0",
+ "penumbra-sdk-funding 2.0.0",
+ "penumbra-sdk-governance 2.0.0",
+ "penumbra-sdk-ibc 2.0.0",
+ "penumbra-sdk-keys 2.0.0",
+ "penumbra-sdk-num 2.0.0",
+ "penumbra-sdk-proof-params 2.0.0",
+ "penumbra-sdk-proto 2.0.0",
+ "penumbra-sdk-sct 2.0.0",
+ "penumbra-sdk-shielded-pool 2.0.0",
+ "penumbra-sdk-stake 2.0.0",
+ "penumbra-sdk-tct 2.0.0",
+ "penumbra-sdk-txhash 2.0.0",
  "poseidon377",
  "rand 0.8.5",
  "rand_core 0.6.4",
@@ -8785,15 +8785,15 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-txhash"
-version = "2.0.0-alpha.12"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0-alpha.12#ab93b98ab0616b3f03b279c650dbdb73636f3a80"
+version = "2.0.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v2.0.0#f0d75958d44c9e946102731e3ace3ac51f5cccc8"
 dependencies = [
  "anyhow",
  "blake2b_simd 1.0.3",
  "getrandom 0.2.16",
  "hex",
- "penumbra-sdk-proto 2.0.0-alpha.12",
- "penumbra-sdk-tct 2.0.0-alpha.12",
+ "penumbra-sdk-proto 2.0.0",
+ "penumbra-sdk-tct 2.0.0",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,11 +69,11 @@ penumbra-sdk-transaction-v1o4 = { package = "penumbra-sdk-transaction", tag = "v
 # v2.x dependencies; APP_VERSION 11
 # This still depends on cnidarium at version 0.83.0, and cargo will complain
 # if we try and add it as a dependency.
-penumbra-sdk-app-v2 = { package = "penumbra-sdk-app", git = "https://github.com/penumbra-zone/penumbra", tag = "v2.0.0-alpha.12"}
-penumbra-sdk-governance-v2 = { package = "penumbra-sdk-governance", git = "https://github.com/penumbra-zone/penumbra", tag = "v2.0.0-alpha.12"}
-penumbra-sdk-ibc-v2 = { package = "penumbra-sdk-ibc", git = "https://github.com/penumbra-zone/penumbra", tag = "v2.0.0-alpha.12"}
-penumbra-sdk-sct-v2 = { package = "penumbra-sdk-sct", git = "https://github.com/penumbra-zone/penumbra", tag = "v2.0.0-alpha.12"}
-penumbra-sdk-transaction-v2 = { package = "penumbra-sdk-transaction", git = "https://github.com/penumbra-zone/penumbra", tag = "v2.0.0-alpha.12"}
+penumbra-sdk-app-v2 = { package = "penumbra-sdk-app", git = "https://github.com/penumbra-zone/penumbra", tag = "v2.0.0"}
+penumbra-sdk-governance-v2 = { package = "penumbra-sdk-governance", git = "https://github.com/penumbra-zone/penumbra", tag = "v2.0.0"}
+penumbra-sdk-ibc-v2 = { package = "penumbra-sdk-ibc", git = "https://github.com/penumbra-zone/penumbra", tag = "v2.0.0"}
+penumbra-sdk-sct-v2 = { package = "penumbra-sdk-sct", git = "https://github.com/penumbra-zone/penumbra", tag = "v2.0.0"}
+penumbra-sdk-transaction-v2 = { package = "penumbra-sdk-transaction", git = "https://github.com/penumbra-zone/penumbra", tag = "v2.0.0"}
 
 sha2 = { version = "0.10.8", default-features = false }
 digest = { version = "0.10.7", default-features = false }

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ and then resume the node, if you'd like an in-situ archive.
 
 ### Regenerating with new Events
 
-Let's say you have a full archive database, up to say, block `600123`, post upgrade,
+Let's say you have a full archive database, up to say, block `5500000`, post-upgrade,
 and would like to recreate an events database.
 (Maybe you ran a node up to this height without configuring it to index into Postgres, woops).
 
@@ -87,13 +87,14 @@ and you want to store the state in `/tmp/regen`, you'd do:
 penumbra-reindexer regen --database-url postgresql://localhost:5432/penumbra_raw?sslmode=disable --working-dir /tmp/regen --stop-height 501974
 penumbra-reindexer regen --database-url postgresql://localhost:5432/penumbra_raw?sslmode=disable --working-dir /tmp/regen --stop-height 2611799
 penumbra-reindexer regen --database-url postgresql://localhost:5432/penumbra_raw?sslmode=disable --working-dir /tmp/regen --stop-height 4378761
+penumbra-reindexer regen --database-url postgresql://localhost:5432/penumbra_raw?sslmode=disable --working-dir /tmp/regen --stop-height 5480873
 penumbra-reindexer regen --database-url postgresql://localhost:5432/penumbra_raw?sslmode=disable --working-dir /tmp/regen
 ```
 
-Unfortunately, we have to run the logic twice, because the Penumbra crate will kill our process after it halts pre-upgrade,
-after block `501974`.
-Post-upgrade, we will run until we process the last block in our archive `600123`.
-After running these commands, the raw event database should have all events up to and including height `600123`.
+Unfortunately, we have to run the logic multiple times, because the Penumbra crate will kill our process after it halts pre-upgrade,
+after block `501974`, and after upgrade boundary thereafter.
+Post-upgrade, we will run until we process the last block in our archive `5500123`.
+After running these commands, the raw event database should have all events up to and including height `5500123`.
 
 ### Starting a node without a Snapshot
 

--- a/src/penumbra.rs
+++ b/src/penumbra.rs
@@ -388,6 +388,14 @@ impl RegenerationPlan {
                     InitThenRunTo {
                         genesis_height: 4378762,
                         version: V1o4,
+                        last_block: Some(5480872),
+                    },
+                ),
+                (
+                    5480872,
+                    InitThenRunTo {
+                        genesis_height: 5480873,
+                        version: V2,
                         last_block: None,
                     },
                 ),

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -487,8 +487,15 @@ impl HistoricalArchiveSeries {
             },
 
             HistoricalArchive {
-                download_url: "https://artifacts.plinfra.net/penumbra-1/penumbra-node-archive-height-4027443.tar.gz".try_into()?,
-                checksum_sha256: "cfb93391ae348275b221bb1811d59833b4bc2854c92c234fe266506b4a6b7c71".to_owned(),
+                download_url: "https://artifacts.plinfra.net/penumbra-1/penumbra-node-archive-height-4378762-pre-upgrade.tar.gz".try_into()?,
+                checksum_sha256: "9840c4d0c93a928412fc55faa6edfe69faa19aac662cc133d6a45c64d1e0062c".to_owned(),
+                chain_id: chain_id.clone(),
+                dest_dir: dest_dir.clone(),
+            },
+
+            HistoricalArchive {
+                download_url: "https://artifacts.plinfra.net/penumbra-1/penumbra-node-archive-height-5480873-pre-upgrade.tar.gz".try_into()?,
+                checksum_sha256: "e83a2e8925dc1a6a4461ac5ce09ed1c68e451444e1854606de8b0d23d6482510".to_owned(),
                 chain_id: chain_id.clone(),
                 dest_dir: dest_dir.clone(),
             },

--- a/tests/penumbra_1.rs
+++ b/tests/penumbra_1.rs
@@ -26,9 +26,24 @@ async fn run_reindexer_archive_step_2() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
-/// Run `penumbra-reindexer archive` from the second upgrade boundary to the present.
+/// Run `penumbra-reindexer archive` from the second upgrade boundary to the third.
 async fn run_reindexer_archive_step_3() -> anyhow::Result<()> {
     let expected_blocks = 4027443;
     run_reindexer_archive_step(PENUMBRA_CHAIN_ID, 2, expected_blocks).await?;
+    Ok(())
+}
+#[tokio::test]
+/// Run `penumbra-reindexer archive` from the third upgrade boundary to the fourth.
+async fn run_reindexer_archive_step_4() -> anyhow::Result<()> {
+    let expected_blocks = 4027443;
+    run_reindexer_archive_step(PENUMBRA_CHAIN_ID, 3, expected_blocks).await?;
+    Ok(())
+}
+
+#[tokio::test]
+/// Run `penumbra-reindexer archive` from the fourth upgrade boundary to the present.
+async fn run_reindexer_archive_step_5() -> anyhow::Result<()> {
+    let expected_blocks = 5480873;
+    run_reindexer_archive_step(PENUMBRA_CHAIN_ID, 4, expected_blocks).await?;
     Ok(())
 }


### PR DESCRIPTION
Bumps the penumbra crate deps to `v2.0.0` across the board, since that version is currently used by both testnet and mainnet.

Also updates the "archive" integration tests with recent archives for penumbra-1.