### PR TITLE
feat: bootstrap mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1247,6 +1247,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1866,6 +1879,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -3472,6 +3491,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+dependencies = [
+ "console",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+ "web-time",
+]
+
+[[package]]
 name = "informalsystems-pbjson"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4054,6 +4086,12 @@ dependencies = [
  "hermit-abi",
  "libc",
 ]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
@@ -6100,6 +6138,7 @@ dependencies = [
  "futures-core",
  "hex",
  "ibc-types 0.12.1",
+ "indicatif",
  "penumbra-app 0.79.7",
  "penumbra-app 0.80.13",
  "penumbra-app 0.81.3",
@@ -11983,6 +12022,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
+
+[[package]]
 name = "unicode-xid"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12201,6 +12246,16 @@ name = "web-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,12 @@ anyhow = "1"
 async-trait = "0.1.81"
 clap = { version = "4", features = ["derive"] }
 directories = "5.0.1"
+flate2 = "1.0.35"
 hex = "0.4.3"
 ibc-types = "0.12.0"
 serde_json = "1.0.125"
 sqlx = { version = "0.8.0", features = ["runtime-tokio", "sqlite", "postgres", "tls-rustls"] }
+tar = "0.4.43"
 tendermint-proto = { version = "0.40.1", default-features = false }
 tendermint_v0o34 = { package = "tendermint", version = "0.34.0", default-features = false }
 tendermint_v0o40 = { package = "tendermint", version = "0.40.1", default-features = false }
@@ -29,6 +31,7 @@ tokio = { version = "1.39.3", features = ["rt"] }
 toml = "0.8.19"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
+url = "2.5.4"
 
 # Namespaced Penumbra versions, so migration modules can run the correct logic for different parts of
 # historical chain state. See docs at https://github.com/penumbra-zone/penumbra/blob/main/COMPATIBILITY.md
@@ -81,7 +84,8 @@ prost = "0.13"
 tokio-stream = "0.1.17"
 futures-core = "0.3.31"
 async-stream = "0.3.6"
-reqwest = { version = "0.12.12", features = ["gzip", "json"] }
+reqwest = { version = "0.12.12", features = ["gzip", "json", "stream"] }
+indicatif = "0.17.11"
 
 # config for cargo release
 [workspace.metadata.release]
@@ -108,9 +112,6 @@ opt-level = 3
 
 [dev-dependencies]
 assert_cmd = "2.0.16"
+directories = "5.0.1"
 escargot = "0.5.13"
-flate2 = "1.0.35"
 reqwest = { version = "0.12.12", features = ["json", "stream"] }
-tar = "0.4.43"
-tokio-stream = "0.1.17"
-url = "2.5.4"

--- a/justfile
+++ b/justfile
@@ -13,8 +13,16 @@ test:
 
 # Run network integration tests. Requires a LOT of disk space and bandwidth!
 integration:
-  rm -rf test_data/ephemeral-storage/
-  cargo nextest run --release --features network-integration --nocapture
+  # don't nuke all storage, we need some of this
+  # rm -rf test_data/ephemeral-storage/
+  # TODO we should port the logic back into cargo-nextest
+  # cargo nextest run --release --features network-integration --nocapture
+
+  cargo run -- bootstrap --home test_data/ephemeral-storage --force
+  cargo run -- archive --home test_data/ephemeral-storage --remote-rpc https://rpc-penumbra.radiantcommons.com
+  cargo run -- check --home test_data/ephemeral-storage
+  # TODO: use picturesque to set up a local psql db for testing
+  # cargo run -- regen --home test_data/ephemeral-storage --database-url postgresql://penumbra:penumbra@127.0.0.1:5432/regen
 
 # Run expensive tests that require local files as input. Assumes integration tests have been run!
 expensive-tests:

--- a/src/check.rs
+++ b/src/check.rs
@@ -1,0 +1,165 @@
+//! Logic to inspect reindexer-generated archives and databases
+//! to perform health checks. Useful for validating assumptions
+//! about how comprehensive a given archive is in particular, as downstream
+//! consumers of raw events databases, such as pindexer, will require
+//! every single historical block up to current height.
+use sqlx::sqlite::SqlitePool;
+use sqlx::PgPool;
+use sqlx::{Error, FromRow, Row};
+use std::path::Path;
+
+// Allowing dead_code because no logic explicitly reads from the `gap_start` and `gap_end` fields;
+// these are used via debug-printing, but debug derivations don't count as live code.
+#[allow(dead_code)]
+#[derive(Debug)]
+/// Representation of a range of missing blocks.
+///
+/// Used to check that created databases are complete, in that they're fully contiguous:
+/// no blocks are absent from the range specified.
+pub struct BlockGap {
+    /// The first block in the range.
+    gap_start: i64,
+    /// The last block in the range.
+    gap_end: i64,
+}
+
+/// Ensure that we can query the sqlite3 db and receive BlockGap results.
+impl<'r> FromRow<'r, sqlx::sqlite::SqliteRow> for BlockGap {
+    fn from_row(row: &'r sqlx::sqlite::SqliteRow) -> Result<Self, Error> {
+        Ok(BlockGap {
+            gap_start: row.try_get("gap_start")?,
+            gap_end: row.try_get("gap_end")?,
+        })
+    }
+}
+
+/// Ensure that we can query the postgres db and receive BlockGap results.
+impl<'r> FromRow<'r, sqlx::postgres::PgRow> for BlockGap {
+    fn from_row(row: &'r sqlx::postgres::PgRow) -> Result<Self, Error> {
+        Ok(BlockGap {
+            gap_start: row.try_get("gap_start")?,
+            gap_end: row.try_get("gap_end")?,
+        })
+    }
+}
+
+/// Query the sqlite3 database for total number of `genesis`,
+/// and expect that the total number is one greater than the current step.
+pub async fn check_num_geneses(reindexer_db_filepath: &Path, step: usize) -> anyhow::Result<()> {
+    // Connect to the database
+    let pool = SqlitePool::connect(reindexer_db_filepath.to_str().unwrap()).await?;
+    let query = sqlx::query("SELECT COUNT(*) FROM geneses;");
+    let count: u64 = query.fetch_one(&pool).await?.get(0);
+    let expected: u64 = step as u64 + 1;
+    if count != expected {
+        tracing::error!(
+            count,
+            expected,
+            "expected {} geneses, but found {}",
+            expected,
+            count
+        );
+        anyhow::bail!("failed genesis count")
+    }
+    Ok(())
+}
+
+/// Query the sqlite3 database for any missing blocks, defined as `BlockGap`s,
+/// and fail if any are found.
+pub async fn check_for_gaps_sqlite(reindexer_db_filepath: &Path) -> anyhow::Result<()> {
+    // Connect to the database
+    let pool = SqlitePool::connect(reindexer_db_filepath.to_str().unwrap()).await?;
+
+    let sql = gaps_query();
+    let query = sqlx::query_as::<_, BlockGap>(&sql);
+    let results = query.fetch_all(&pool).await?;
+
+    // TODO: read fields to format an error message
+    if !results.is_empty() {
+        let msg = format!("found missing blocks in the sqlite3 db: {:?}", results);
+        tracing::error!(msg);
+        anyhow::bail!(msg);
+    }
+    Ok(())
+}
+
+/// Query the postgres database for any missing blocks, defined as `BlockGap`s,
+/// and fail if any are found.
+pub async fn check_for_gaps_postgres(pg_db_url: String) -> anyhow::Result<()> {
+    // Connect to the database
+    let pool = PgPool::connect(pg_db_url.as_str()).await?;
+
+    let sql = gaps_query();
+    let query = sqlx::query_as::<_, BlockGap>(&sql);
+    let results = query.fetch_all(&pool).await?;
+
+    // TODO: read fields to format an error message
+    if !results.is_empty() {
+        let msg = format!("found missing blocks in the postgres db: {:?}", results);
+        tracing::error!(msg);
+        anyhow::bail!(msg);
+    }
+    Ok(())
+}
+
+/// Private function for generating SQL that checks for gaps within a database.
+fn gaps_query() -> String {
+    String::from(
+        r#"
+    WITH numbered_blocks AS (
+        SELECT height,
+               LEAD(height) OVER (ORDER BY height) as next_height
+        FROM blocks
+    )
+    SELECT height + 1 as gap_start, next_height - 1 as gap_end
+    FROM numbered_blocks
+    WHERE next_height - height > 1
+    "#,
+    )
+}
+
+/// Query the sqlite3 database for total number of known blocks.
+/// Fail if it doesn't match the expected number of blocks, or
+/// 1 less than the expected number. The tolerance is to acknowledge
+/// that the sqlite3 db can be 1 block behind the local node state.
+pub async fn check_num_blocks_sqlite(
+    reindexer_db_filepath: &Path,
+    expected: u64,
+) -> anyhow::Result<u64> {
+    // Connect to the database
+    let pool = SqlitePool::connect(reindexer_db_filepath.to_str().unwrap()).await?;
+    let query = sqlx::query("SELECT COUNT(*) FROM blocks");
+    let count: u64 = query.fetch_one(&pool).await?.get(0);
+
+    if ![expected, expected - 1].contains(&count) {
+        let msg = format!(
+            "archived blocks count looks wrong; expected: {}, found {}",
+            expected, count,
+        );
+        tracing::error!(msg);
+        anyhow::bail!(msg);
+    }
+
+    Ok(count)
+}
+
+/// Query the postgres database for total number of known blocks.
+/// Fail if it doesn't match the expected number of blocks, or
+/// 1 less than the expected number. The tolerance is to acknowledge
+/// that the postgres db can be 1 block behind the local node state.
+pub async fn check_num_blocks_postgres(pg_db_url: String, expected: u64) -> anyhow::Result<u64> {
+    // Connect to the database
+    let pool = PgPool::connect(pg_db_url.as_str()).await?;
+    let query = sqlx::query("SELECT COUNT(*) FROM blocks");
+    let count_raw: i64 = query.fetch_one(&pool).await?.get(0);
+    let count = count_raw as u64;
+    if ![expected, expected - 1].contains(&count) {
+        let msg = format!(
+            "regenerated blocks count looks wrong; expected: {}, found {}",
+            expected, count,
+        );
+        tracing::error!(msg);
+        anyhow::bail!(msg);
+    }
+    Ok(count)
+}

--- a/src/cometbft/remote.rs
+++ b/src/cometbft/remote.rs
@@ -1,9 +1,10 @@
 use anyhow::anyhow;
 use async_stream::try_stream;
 use async_trait::async_trait;
+use indicatif::{ProgressBar, ProgressStyle};
 use reqwest::Client;
 use serde_json::Value;
-use std::{ops::Range, time::Duration};
+use std::{io::IsTerminal, ops::Range, time::Duration};
 use tokio::time::Instant;
 
 use super::{Block, BlockStream, Genesis};
@@ -126,6 +127,15 @@ impl super::Store for RemoteStore {
         let this = self.clone();
         let mut height = start.unwrap_or(1);
         let stream = try_stream! {
+            // Determine if we should show fancy progress or use headless logging
+            let use_progress_bar = std::io::stderr().is_terminal();
+            let mut progress_bar: Option<ProgressBar> = None;
+
+            // For headless mode, setup periodic logging
+            let mut last_log_time = Instant::now();
+            let log_interval = Duration::from_secs(10); // More frequent than download logging
+            let start_time = Instant::now();
+
             while end.map(|x| height <= x).unwrap_or(true) {
                 let poll_start_time = Instant::now();
                 let most_recent_block = {
@@ -138,6 +148,20 @@ impl super::Store for RemoteStore {
                     }
                     most_recent_block
                 };
+
+                // Initialize progress bar if we haven't already and we know the end
+                if progress_bar.is_none() && end.is_some() && use_progress_bar {
+                    let total = end.unwrap() - height + 1;
+                    let pb = ProgressBar::new(total);
+                    pb.set_style(
+                        ProgressStyle::default_bar()
+                            .template("{spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] {pos}/{len} blocks ({per_sec}, {eta})")?
+                            .progress_chars("##-")
+                    );
+                    pb.set_message("Syncing blocks from remote store");
+                    progress_bar = Some(pb);
+                }
+
                 // In the case where height = most_recent_block, we have not yet indexed the last block.
                 while height <= most_recent_block {
                     let request_start_time = Instant::now();
@@ -146,11 +170,56 @@ impl super::Store for RemoteStore {
                         // Macro shenanigans.
                         Err(anyhow!("RPC returned an empty list of blocks"))?;
                     }
-                    tracing::info!(
-                        start_height = buf.first().expect("buf is not empty").height,
-                        end_height = buf.last().expect("buf is not empty").height,
-                        "new blocks from remote store"
-                    );
+
+                    let start_block = buf.first().expect("buf is not empty").height;
+                    let end_block = buf.last().expect("buf is not empty").height;
+
+                    // Update progress bar in interactive mode
+                    if let Some(ref pb) = progress_bar {
+                        pb.set_position(height - start.unwrap_or(1));
+                        pb.set_message(format!("Processing blocks {}-{}", start_block, end_block));
+                    // In headless mode, log periodically
+                    } else if !use_progress_bar && last_log_time.elapsed() >= log_interval {
+                        let elapsed = start_time.elapsed();
+                        let blocks_processed = height - start.unwrap_or(1);
+                        let rate = if elapsed.as_secs() > 0 {
+                            blocks_processed as f64 / elapsed.as_secs_f64()
+                        } else {
+                            0.0
+                        };
+
+                        if let Some(end_height) = end {
+                            let total_blocks = end_height - start.unwrap_or(1) + 1;
+                            let percentage = (blocks_processed as f64 / total_blocks as f64) * 100.0;
+                            let remaining_blocks = total_blocks - blocks_processed;
+                            let eta = if rate > 0.0 {
+                                Duration::from_secs((remaining_blocks as f64 / rate) as u64)
+                            } else {
+                                Duration::from_secs(0)
+                            };
+
+                            tracing::info!(
+                                "block sync progress: {:.1}% ({} / {} blocks) at {:.1} blocks/s, ETA: {}m{}s",
+                                percentage,
+                                blocks_processed,
+                                total_blocks,
+                                rate,
+                                eta.as_secs() / 60,
+                                eta.as_secs() % 60
+                            );
+                        } else {
+                            tracing::info!(
+                                "block sync progress: {} blocks processed at {:.1} blocks/s (blocks {}-{})",
+                                blocks_processed,
+                                rate,
+                                start_block,
+                                end_block
+                            );
+                        }
+
+                        last_log_time = Instant::now();
+                    }
+
                     for block in buf.into_iter() {
                         let block_height = block.height();
                         if block_height != height {
@@ -163,6 +232,25 @@ impl super::Store for RemoteStore {
                     tokio::time::sleep_until(request_start_time + REQUEST_SLEEP).await;
                 }
                 tokio::time::sleep_until(poll_start_time + POLL_SLEEP).await;
+            }
+
+            // Finish progress reporting
+            if let Some(pb) = progress_bar {
+                pb.finish_with_message("Block sync completed");
+            } else if !use_progress_bar {
+                let elapsed = start_time.elapsed();
+                let blocks_processed = height - start.unwrap_or(1);
+                let avg_rate = if elapsed.as_secs() > 0 {
+                    blocks_processed as f64 / elapsed.as_secs_f64()
+                } else {
+                    0.0
+                };
+                tracing::info!(
+                    "block sync completed: {} blocks in {:.1}s (avg {:.1} blocks/s)",
+                    blocks_processed,
+                    elapsed.as_secs_f64(),
+                    avg_rate
+                );
             }
         };
         Box::pin(stream)

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,7 +1,9 @@
 mod archive;
+mod bootstrap;
 mod export;
 mod regen;
 
 pub use archive::Archive;
+pub use bootstrap::Bootstrap;
 pub use export::Export;
 pub use regen::Regen;

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,9 +1,11 @@
 mod archive;
 mod bootstrap;
+mod check;
 mod export;
 mod regen;
 
 pub use archive::Archive;
 pub use bootstrap::Bootstrap;
+pub use check::Check;
 pub use export::Export;
 pub use regen::Regen;

--- a/src/command/archive.rs
+++ b/src/command/archive.rs
@@ -26,13 +26,12 @@ pub struct Archive {
     /// In this directory we expect there to be:
     ///
     /// - ./cometbft/config/config.toml, for reading cometbft configuration
-    ///
-    /// - ./reindexer_archive.bin (maybe), for existing archive data to append to
+    /// - ./cometbft/data/, for reading historical blocks
     ///
     /// Defaults to `~/.penumbra/network_data/node0`, the same default used for `pd start`.
     ///
     /// The node state will be read from this directory, and saved inside
-    /// an sqlite3 at within ~/.local/share/penumbra-reindexer/<CHAIN_ID>/reindexer-archive.sqlite.
+    /// an sqlite3 database at ~/.local/share/penumbra-reindexer/<CHAIN_ID>/reindexer-archive.sqlite.
     ///
     /// Read usage can be overridden with --cometbft-dir.
     /// Write usage can be overridden with --archive-file.

--- a/src/command/archive.rs
+++ b/src/command/archive.rs
@@ -212,8 +212,12 @@ impl Archiver {
         tracing::info!("archiving blocks {}..{}", start, end);
         let mut block_stream = self.store.stream_blocks(Some(start), Some(end));
         while let Some((height, block)) = block_stream.try_next().await? {
+            use std::io::IsTerminal;
             if (height - start) % 10_000 == 0 {
-                tracing::info!("archiving block {}", height);
+                // If tty, there will be a progress bar, so skip info-level logging
+                if !std::io::stderr().is_terminal() {
+                    tracing::info!("archiving block {}", height);
+                }
             } else {
                 tracing::debug!("archiving block {}", height);
             }

--- a/src/command/archive.rs
+++ b/src/command/archive.rs
@@ -65,7 +65,7 @@ pub struct Archive {
     #[clap(long)]
     remote_rpc: Option<String>,
 
-    /// Set a specificy chain id
+    /// Set a specific chain id
     #[clap(long)]
     chain_id: Option<String>,
 }

--- a/src/command/bootstrap.rs
+++ b/src/command/bootstrap.rs
@@ -1,0 +1,140 @@
+use anyhow::Context;
+use std::path::PathBuf;
+
+use crate::files::archive_filepath_from_opts;
+
+#[derive(clap::Parser)]
+pub struct Bootstrap {
+    /// The home directory for the penumbra-reindexer.
+    ///
+    /// Downloaded large files will be stored within this directory.
+    ///
+    /// Defaults to `~/.local/share/penumbra-reindexer`.
+    /// Can be overridden with --archive-file.
+    #[clap(long)]
+    home: Option<PathBuf>,
+
+    /// Override the filepath for the sqlite3 database.
+    /// Defaults to <REINDEXER_HOME>/<CHAIN_ID>/reindexer-archive.sqlite
+    #[clap(long)]
+    archive_file: Option<PathBuf>,
+
+    /// Declare a specific chain id to bootstrap a config for.
+    ///
+    /// Returns an error if the specified chain id is not supported.
+    /// Defaults to `penumbra-1` for mainnet.
+    #[clap(long)]
+    chain_id: Option<String>,
+
+    /// Use a remote CometBFT RPC URL to fetch chain id from.
+    ///
+    /// Setting this option will pool a remote node for chain info,
+    /// and initialize event archives based on the `chain_id` returned,
+    /// if supported.
+    #[clap(long)]
+    remote_rpc: Option<String>,
+
+    /// Overwrite any pre-existing reindexer archive for the relevant chain.
+    ///
+    /// Ensures that the local reindexer archive is reset to match what's configured
+    /// as a remote base storage.
+    #[clap(long)]
+    force: bool,
+}
+
+impl Bootstrap {
+    /// Create config dir, and fetch a remote ReindexerArchive.
+    pub async fn run(self) -> anyhow::Result<()> {
+        // Validate args
+        if self.home.is_some() && self.archive_file.is_some() {
+            tracing::warn!("in correct error state; i think it's fine to keep going here.");
+            anyhow::bail!("cannot use both --home and --archive-file options");
+        }
+
+        // For now, let's default to a reasonable chain id.
+        let chain_id = match self.chain_id {
+            Some(c) => c,
+            None => {
+                tracing::warn!("no chain id specified, defaulting to 'penumbra-1' mainnet");
+                String::from("penumbra-1")
+            }
+        };
+
+        let home = self.home.unwrap_or(crate::files::default_reindexer_home()?);
+        let archive_file = archive_filepath_from_opts(
+            Some(home.clone()),
+            self.archive_file,
+            Some(chain_id.clone()),
+        )?;
+
+        // Create parent directory
+        let par_dir = archive_file
+            .parent()
+            .expect("archive file must have parent directory");
+        if !par_dir.exists() {
+            std::fs::create_dir_all(par_dir)
+                .context("failed to create parent directory for archive file")?;
+        }
+
+        tracing::info!(%chain_id, "bootstrapping reindexer setup");
+        let reindexer_archive = crate::history::ReindexerArchive::try_from(chain_id.clone())?;
+
+        // Get name of file as it will be downloaded
+        let dest_file = home
+            .join(chain_id.clone())
+            .join(crate::history::basename_from_url(
+                &reindexer_archive.download_url,
+            )?);
+
+        // Remember whether archive was downloaded, for appropriate logging messages post-op.
+        let archive_already_existed = archive_file.exists();
+        if dest_file.exists() {
+            tracing::info!(
+                dest_file = dest_file.display().to_string(),
+                "reindexer archive already exists, validating checksum"
+            );
+        }
+
+        reindexer_archive
+            .download(&dest_file)
+            .await
+            .context("failed to download archive_file")?;
+
+        // Extract gzipped file if necessary
+        let final_dest_file = if dest_file.extension().and_then(|s| s.to_str()) == Some("gz") {
+            let extracted_file = dest_file.with_extension("");
+            tracing::info!(
+                compressed_file = dest_file.display().to_string(),
+                extracted_file = extracted_file.display().to_string(),
+                "extracting gzipped archive"
+            );
+            reindexer_archive
+                .extract(&dest_file, &extracted_file)
+                .await
+                .context("failed to extract gzipped archive")?;
+            extracted_file
+        } else {
+            dest_file.clone()
+        };
+
+        // Warn about not clobbering
+        if archive_already_existed && !self.force {
+            tracing::warn!(
+                archive_file = archive_file.display().to_string(),
+                "reindexer archive already exists, not clobbering"
+            );
+        } else {
+            // Copy file over to actual download location. The named params in the logging msg
+            // are reversed.
+            tracing::debug!(
+                src_file = final_dest_file.display().to_string(),
+                dest_file = archive_file.display().to_string(),
+                "copying archive to final location"
+            );
+            std::fs::copy(&final_dest_file, &archive_file)
+                .context("failed to copy reindexer archive to final location after downloading")?;
+        }
+
+        Ok(())
+    }
+}

--- a/src/command/check.rs
+++ b/src/command/check.rs
@@ -1,0 +1,104 @@
+use std::path::PathBuf;
+
+use crate::check;
+use crate::files::archive_filepath_from_opts;
+
+#[derive(clap::Parser)]
+/// Inspect a local SQLite3 database for Penumbra Reindexer, and ensure it's validly
+/// structured. Checks that a db contains all historical blocks, with no gaps,
+/// which can occur when cometbft fails to index a block to its db.
+pub struct Check {
+    #[clap(long)]
+    /// The home directory for the penumbra-reindexer.
+    ///
+    /// Downloaded large files will be stored within this directory.
+    ///
+    /// Defaults to `~/.local/share/penumbra-reindexer`.
+    /// Can be overridden with --archive-file.
+    home: Option<PathBuf>,
+
+    /// Override the filepath for the sqlite3 database.
+    /// Defaults to <HOME>/<CHAIN_ID>/reindexer-archive.sqlite
+    #[clap(long)]
+    archive_file: Option<PathBuf>,
+
+    #[clap(long)]
+    /// Perform healthchecks ensuring a specific chain id. Defaults to `penumbra-1` for mainnet.
+    chain_id: Option<String>,
+
+    /// Use a remote CometBFT RPC URL to fetch chain id from.
+    ///
+    /// Setting this option will pool a remote node for chain info,
+    /// and initialize event archives based on the `chain_id` returned,
+    /// if supported.
+    #[clap(long)]
+    remote_rpc: Option<String>,
+}
+
+impl Check {
+    /// Create config dir, and fetch a remote ReindexerArchive.
+    pub async fn run(self) -> anyhow::Result<()> {
+        // Validate args
+        if self.home.is_some() && self.archive_file.is_some() {
+            anyhow::bail!("cannot use both --home and --archive-file options");
+        }
+
+        // Default to penumbra-1
+        let chain_id = self.chain_id.unwrap_or(String::from("penumbra-1"));
+
+        let archive_file =
+            archive_filepath_from_opts(self.home, self.archive_file, Some(chain_id.clone()))?;
+
+        if !archive_file.exists() {
+            let msg = "archive file does not exist; specify one with `--archive-file`, or run `penumbra-reindexer bootstrap`";
+            tracing::error!(archive_file = archive_file.display().to_string(), msg);
+            anyhow::bail!(msg);
+        }
+
+        tracing::info!(
+            "inspecting local db: {} ",
+            &archive_file.as_path().as_os_str().to_str().unwrap(),
+        );
+
+        // Initialize reporting var
+        let mut failed_checks = 0;
+
+        // To figure out how many geneses should be in the archive,
+        // we'll iterate over all upgrades and count 'em.:
+        let x = crate::history::NodeArchiveSeries::from_chain_id(&chain_id)?;
+        let expected_num_geneses = x.archives.len();
+
+        match check::check_for_gaps_sqlite(&archive_file).await {
+            Ok(_) => println!("✅ no gaps found found"),
+
+            Err(_) => {
+                println!("❌ found gaps of missing blocks");
+                failed_checks = failed_checks + 1;
+            }
+        }
+
+        // TODO check that chain id matches expectations
+
+        match check::check_num_geneses(&archive_file, expected_num_geneses).await {
+            Ok(_) => println!(
+                "✅ found all {} expected genesis records",
+                expected_num_geneses
+            ),
+            Err(_) => {
+                println!(
+                    "❌ genesis records are missing; expected {}",
+                    expected_num_geneses
+                );
+                failed_checks = failed_checks + 1;
+            }
+        }
+        if failed_checks == 0 {
+            println!("💯 finished all checks, archive is valid");
+        } else {
+            println!("👎 failed {} checks", failed_checks);
+            anyhow::bail!("failed {} checks", failed_checks);
+        }
+
+        Ok(())
+    }
+}

--- a/src/command/regen.rs
+++ b/src/command/regen.rs
@@ -12,14 +12,17 @@ pub struct Regen {
     /// The URL for the database where we should store the produced events.
     #[clap(long)]
     database_url: String,
-    /// A home directory to read Penumbra data from.
+    /// The directory containing pd and cometbft data for a full node.
     ///
     /// In this directory we expect there to be:
     ///
     /// - ./cometbft/config/config.toml, for reading cometbft configuration
+    /// - ./cometbft/data/, for reading historical blocks
     ///
-    /// - ./reindexer_archive.bin (maybe), for existing archive data to append to
+    /// Defaults to `~/.penumbra/network_data/node0`, the same default used for `pd start`.
     ///
+    /// The node state will be read from this directory, and saved inside
+    /// an sqlite3 database at ~/.local/share/penumbra-reindexer/<CHAIN_ID>/reindexer-archive.sqlite.
     #[clap(long)]
     node_home: Option<PathBuf>,
 

--- a/src/files.rs
+++ b/src/files.rs
@@ -1,4 +1,5 @@
-use anyhow::anyhow;
+use anyhow::{anyhow, Context};
+use directories::ProjectDirs;
 use std::path::PathBuf;
 
 /// Retrieve the home directory for the user running this program.
@@ -18,5 +19,50 @@ pub fn default_penumbra_home() -> anyhow::Result<PathBuf> {
     Ok(home_dir()?.join(".penumbra/network_data/node0"))
 }
 
+/// Return the default fullpath to a reindexer archive sqlite3 db.
+///
+/// This can fail if home directories aren't available on the machine, for some reason.
+pub(crate) fn default_reindexer_archive_filepath(chain_id: &str) -> anyhow::Result<PathBuf> {
+    Ok(default_reindexer_home()?
+        .join(chain_id)
+        .join(REINDEXER_FILE_NAME))
+}
+
+/// Return the default fullpath to a reindexer data directory,
+/// where large archives will be downloaded and saved. Defaults to
+/// `~/.local/share/penumbra-reindexer`.
+pub fn default_reindexer_home() -> anyhow::Result<PathBuf> {
+    let path = ProjectDirs::from("zone", "penumbra", "penumbra-reindexer")
+        .context("failed to get platform data dir")?
+        .data_dir()
+        .to_path_buf();
+    Ok(path)
+}
+
+/// Get the archive file, based on optional overrides to reindexer home directory,
+/// or an explicit path to the archive sqlite3 db. Reused by several subcommands.
+pub fn archive_filepath_from_opts(
+    home: Option<PathBuf>,
+    archive_file: Option<PathBuf>,
+    chain_id: Option<String>,
+) -> anyhow::Result<PathBuf> {
+    let out = match (home.as_ref(), archive_file.as_ref()) {
+        (None, Some(x)) => x.to_owned(),
+        (Some(x), None) => {
+            let mut buf = x.to_owned();
+            buf.push(chain_id.unwrap_or("penumbra-1".to_owned()));
+            buf.push(REINDEXER_FILE_NAME);
+            buf
+        }
+        (None, None) => default_reindexer_archive_filepath(
+            chain_id.unwrap_or("penumbra-1".to_owned()).as_str(),
+        )?,
+        (Some(_), Some(_)) => {
+            anyhow::bail!("cannot use both --home and --archive-file options");
+        }
+    };
+    Ok(out)
+}
+
 /// The name of the reindexer archive file.
-pub const REINDEXER_FILE_NAME: &str = "reindexer_archive.bin";
+pub const REINDEXER_FILE_NAME: &str = "reindexer-archive.sqlite";

--- a/src/history.rs
+++ b/src/history.rs
@@ -1,0 +1,262 @@
+#![allow(dead_code)]
+//! The history module represents history node archives, suitable
+//! for fetching from remote storage to bootstrap a local configuration.
+//! There are two different types of history:
+//!
+//!   1. NodeArchives, containing pd and cometbft node state at a certain height
+//!   2. ReindexerArchives, containing all cometbft blocks up to a certain height
+//!
+//! The NodeArchives are necessary to create ReindexerArchives; in particular, they're required for
+//! running a full "reindex" which is required when new ABCI events are backported to old protocol
+//! versions.
+
+use anyhow::Context;
+use indicatif::{ProgressBar, ProgressStyle};
+use reqwest::Client;
+use sha2::{Digest, Sha256};
+use std::io::{IsTerminal, Write};
+use std::path::Path;
+use std::time::{Duration, Instant};
+use tokio_stream::StreamExt as _;
+use url::Url;
+
+mod node;
+mod reindexer;
+
+pub use node::{NodeArchive, NodeArchiveSeries};
+
+pub use reindexer::ReindexerArchive;
+
+/// Fetch the archive from the `download_url` and save it locally with optional fancy progress bar.
+///
+/// In terms of developer experience, this function automatically detects if it's running in an
+/// interactive terminal and shows a progress bar accordingly.
+/// In headless environments, it falls back to periodic log messages.
+///
+// This is a rather verbose function, mostly because it supports pretty progress bars
+// in interactive terminal sessions. Would be nice to factor out some of the logic.
+pub async fn download(
+    download_url: &Url,
+    dest_file: &Path,
+    checksum_sha256: &str,
+) -> anyhow::Result<()> {
+    if dest_file.exists() {
+        tracing::debug!(
+            dest_file = dest_file.display().to_string(),
+            "file exists, comparing checksum"
+        );
+        let existing_hash = get_sha256sum(dest_file)?;
+        if existing_hash == checksum_sha256 {
+            tracing::debug!(
+                "archive already exists with correct hash: {} {}",
+                dest_file.display(),
+                checksum_sha256,
+            );
+            return Ok(());
+        } else {
+            tracing::warn!(
+                "archive failed to verify via checksum: {} ; expected {}, got {}",
+                dest_file.display(),
+                checksum_sha256,
+                existing_hash,
+            );
+            tracing::warn!("re-downloading archive: {}", dest_file.display());
+        }
+    }
+
+    // Create all parent directories before attempting to download file.
+    if let Some(parent) = dest_file.parent() {
+        tracing::debug!(?parent, "creating parent directory prior to downloading");
+        std::fs::create_dir_all(parent)?;
+    }
+
+    tracing::info!(%download_url, dest_file=dest_file.display().to_string(), "downloading archive");
+
+    // Determine if we should show fancy progress or use headless logging
+    let use_progress_bar = std::io::stderr().is_terminal();
+
+    // Create HTTP client for both HEAD and GET requests
+    let client = Client::new();
+
+    // Send HEAD request to get content length
+    let total_size = match client.head(download_url.clone()).send().await {
+        Ok(response) => response
+            .headers()
+            .get("content-length")
+            .and_then(|ct| ct.to_str().ok())
+            .and_then(|ct| ct.parse::<u64>().ok())
+            .unwrap_or(0),
+        Err(_) => {
+            tracing::error!("failed to get content-length via HEAD request");
+            0
+        }
+    };
+
+    if total_size > 0 {
+        tracing::debug!(
+            "download size: {} bytes ({:.2} MB)",
+            total_size,
+            total_size as f64 / 1_048_576.0
+        );
+    } else {
+        tracing::debug!("download size: unknown");
+    }
+
+    // Setup progress tracking
+    let progress_bar = if use_progress_bar {
+        let pb = ProgressBar::new(total_size);
+
+        if total_size > 0 {
+            pb.set_style(
+                ProgressStyle::default_bar()
+                    .template("{spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] {bytes}/{total_bytes} ({bytes_per_sec}, {eta})")
+                    .context("failed to set progress bar template")?
+                    .progress_chars("##-"),
+            );
+        } else {
+            pb.set_style(
+                ProgressStyle::default_spinner()
+                    .template(
+                        "{spinner:.green} [{elapsed_precise}] {bytes} downloaded ({bytes_per_sec})",
+                    )
+                    .context("failed to set progress bar template")?,
+            );
+        }
+
+        pb.set_message("Downloading...");
+        Some(pb)
+    } else {
+        None
+    };
+
+    // For headless mode, e.g. running in batch jobs, setup periodic logging
+    let mut last_log_time = Instant::now();
+    let log_interval = Duration::from_secs(60);
+    let mut last_logged_bytes = 0u64;
+
+    // Start the actual download
+    let response = client.get(download_url.clone()).send().await?;
+
+    // Check if request was successful
+    if !response.status().is_success() {
+        if let Some(pb) = &progress_bar {
+            pb.abandon_with_message("Download failed");
+        }
+        anyhow::bail!("Failed to download: HTTP {}", response.status());
+    }
+
+    // Create file with same options as original
+    let mut download_opts = std::fs::OpenOptions::new();
+    download_opts.create(true).write(true).truncate(true);
+    let mut f = download_opts
+        .open(dest_file)
+        .context("failed to open dest filepath for downloading archive")?;
+
+    // Download via stream
+    let mut stream = response.bytes_stream();
+    let mut downloaded = 0u64;
+    let start_time = Instant::now();
+
+    while let Some(chunk_result) = stream.next().await {
+        let chunk = chunk_result?;
+        f.write_all(&chunk)?;
+
+        downloaded += chunk.len() as u64;
+
+        // Update progress bar if in headful mode
+        if let Some(pb) = &progress_bar {
+            pb.set_position(downloaded);
+
+            if total_size > 0 {
+                let percentage = (downloaded as f64 / total_size as f64) * 100.0;
+                pb.set_message(format!("Downloading... {:.1}%", percentage));
+            } else {
+                pb.set_message("Downloading...");
+            }
+        // In headless mode, log periodically
+        } else if last_log_time.elapsed() >= log_interval {
+            let elapsed = start_time.elapsed();
+            let speed = if elapsed.as_secs() > 0 {
+                (downloaded - last_logged_bytes) as f64 / elapsed.as_secs_f64()
+            } else {
+                0.0
+            };
+
+            if total_size > 0 {
+                let percentage = (downloaded as f64 / total_size as f64) * 100.0;
+                tracing::info!(
+                    "download progress: {:.1}% ({:.2} MB / {:.2} MB) at {:.2} MB/s",
+                    percentage,
+                    downloaded as f64 / 1_048_576.0,
+                    total_size as f64 / 1_048_576.0,
+                    speed / 1_048_576.0
+                );
+            } else {
+                tracing::info!(
+                    "download progress: {:.2} MB downloaded at {:.2} MB/s",
+                    downloaded as f64 / 1_048_576.0,
+                    speed / 1_048_576.0
+                );
+            }
+
+            last_log_time = Instant::now();
+            last_logged_bytes = downloaded;
+        }
+    }
+
+    f.flush()?;
+
+    // Finish progress reporting
+    if let Some(pb) = &progress_bar {
+        pb.finish_with_message("Download completed");
+    } else {
+        let elapsed = start_time.elapsed();
+        let avg_speed = if elapsed.as_secs() > 0 {
+            downloaded as f64 / elapsed.as_secs_f64() / 1_048_576.0
+        } else {
+            0.0
+        };
+        tracing::info!(
+            "download completed: {:.2} MB in {:.1}s (avg {:.2} MB/s)",
+            downloaded as f64 / 1_048_576.0,
+            elapsed.as_secs_f64(),
+            avg_speed
+        );
+    }
+
+    // Verify checksum post-download.
+    tracing::debug!("verifying checksum");
+    let actual_checksum = get_sha256sum(dest_file)?;
+    if actual_checksum != checksum_sha256 {
+        let msg = format!(
+            "archive failed to verify via checksum: {} ; expected {}, got {}",
+            dest_file.display(),
+            checksum_sha256,
+            actual_checksum,
+        );
+        tracing::error!(msg);
+        anyhow::bail!(msg);
+    }
+
+    tracing::info!("download complete: {}", dest_file.display());
+    Ok(())
+}
+
+/// Determine a reasonable filename for the archive, based on a URL.
+pub fn basename_from_url(download_url: &Url) -> anyhow::Result<String> {
+    let basename = download_url
+        .path_segments()
+        .ok_or_else(|| anyhow::anyhow!("URL has no path segments"))?
+        .last()
+        .ok_or_else(|| anyhow::anyhow!("URL has no basename"))?;
+
+    Ok(basename.to_string())
+}
+
+/// Utility function to grab a sha256sum for a target file.
+fn get_sha256sum<P: AsRef<Path>>(path: P) -> anyhow::Result<String> {
+    let mut file = std::fs::File::open(path)?;
+    let mut hasher = Sha256::new();
+    std::io::copy(&mut file, &mut hasher)?;
+    Ok(format!("{:x}", hasher.finalize()))
+}

--- a/src/history/node.rs
+++ b/src/history/node.rs
@@ -1,0 +1,217 @@
+use anyhow::Context;
+use flate2::read::GzDecoder;
+use std::io::Write;
+use std::path::PathBuf;
+use url::Url;
+
+/// An compressed file archive containing historical node state.
+///
+/// The expected structure is quite strict: should be a `.tar.gz`
+/// file, containing only `comebtft/data` and `pd/rocksdb` directories,
+/// so that it can be extracted on top of an existing `node0` dir.
+///
+/// Requires a download URL so the archive can be fetched, and a checksum
+/// so that the integrity can be verified.
+pub struct NodeArchive {
+    /// The chain id of the chain for which the archive provides history.
+    pub chain_id: String,
+    /// The URL from which the archive will be downloaded.
+    pub download_url: Url,
+    /// The SHA256 checksum for verifying the integrity of the archive post-download.
+    pub checksum_sha256: String,
+}
+
+impl NodeArchive {
+    /// Determine a reasonable fullpath for the archive locally,
+    /// based on the `dest_dir` and `download_url`.
+    pub fn dest_file(&self) -> anyhow::Result<PathBuf> {
+        // TODO: reindexer dir in `~/.penumbra/network_data/node0/reindexer`?
+        Ok(self
+            .node_dir()
+            .join(crate::history::basename_from_url(&self.download_url)?))
+    }
+
+    /// Take an archive, assumed to be in `.tar.gz` format, and decompress it
+    /// across the `node0` directory for a Penumbra node.
+    pub async fn extract(
+        &self,
+        archive_filepath: &PathBuf,
+        dest_dir: &PathBuf,
+    ) -> anyhow::Result<()> {
+        let mut unpack_opts = std::fs::OpenOptions::new();
+        unpack_opts.read(true);
+        let f = unpack_opts
+            .open(archive_filepath)
+            .context("failed to open local archive for extraction")?;
+        let tar = GzDecoder::new(f);
+        let mut archive = tar::Archive::new(tar);
+        archive
+            .unpack(dest_dir)
+            .context("failed to extract tar.gz archive")?;
+        Ok(())
+    }
+
+    /// Fetch the archive from the `download_url` and save it locally.
+    // TODO: make fn accept dest_file as arg
+    pub async fn download(&self) -> anyhow::Result<()> {
+        let dest_file = self.dest_file()?;
+        crate::history::download(&self.download_url, &dest_file, &self.checksum_sha256).await?;
+        Ok(())
+    }
+
+    /// We need a real genesis file for the relevant network, in place within the CometBFT config.
+    /// Generating an ad-hoc network will generate a random genesis, so this fn clobbers it.
+    /// Accepts a `step` argument so that the appropriate genesis file for the chain state is
+    /// fetched, which is important for the `archive` functionality.
+    pub async fn fetch_genesis(&self, step: usize) -> anyhow::Result<()> {
+        let genesis_url = format!(
+            "https://artifacts.plinfra.net/{}/genesis-{}.json",
+            self.chain_id, step
+        );
+
+        tracing::debug!(genesis_url, "fetching");
+        let r = reqwest::get(genesis_url).await?.error_for_status()?;
+        let genesis_content = r.text().await?;
+
+        let genesis_filepath = self
+            .node_dir()
+            .join("cometbft")
+            .join("config")
+            .join("genesis.json");
+
+        // Ensure pardirs are present
+        if let Some(parent) = genesis_filepath.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        // Open file for writing (this will create it if it doesn't exist)
+        let mut f = std::fs::File::create(&genesis_filepath)?;
+        f.write_all(genesis_content.as_bytes())?;
+
+        Ok(())
+    }
+
+    /// Look up the node directory, by appending `node0`
+    /// to the `network_dir`.
+    pub fn node_dir(&self) -> PathBuf {
+        crate::files::default_penumbra_home()
+            .expect("failed to look up default penumbra home directory")
+    }
+
+    /// Obtain filepath to the sqlite3 database created by `penumbra-reindexer archive`.
+    pub fn reindexer_db_filepath(&self) -> PathBuf {
+        self.node_dir().join(crate::files::REINDEXER_FILE_NAME)
+    }
+}
+
+/// A complete set of [NodeArchive]s, constituting
+/// the entirety of blocks on a given chain. Assumes that
+/// each archive contains all blocks for a specific protocol version,
+/// with upgrade boundaries implied between each archive.
+///
+pub struct NodeArchiveSeries {
+    /// The chain id of the chain represented by the archive series.
+    chain_id: String,
+    /// The historical archives representing chain state over multiple versions.
+    pub archives: Vec<NodeArchive>,
+}
+
+impl NodeArchiveSeries {
+    /// Parse a chain id to determine whether that network is supported
+    /// by the reindexer test suite.
+    pub fn from_chain_id(chain_id: &str) -> anyhow::Result<Self> {
+        if chain_id == "penumbra-testnet-phobos-2" {
+            let archives = Self::for_penumbra_testnet_phobos_2()?;
+            Ok(archives)
+        } else if chain_id == "penumbra-1" {
+            let archives = Self::for_penumbra_1()?;
+            Ok(archives)
+        } else {
+            anyhow::bail!("chain id '{}' not supported", chain_id);
+        }
+    }
+
+    /// List all sequential node state archives required
+    /// to reconstruct chain state for `penumbra-testnet-phobos-2`.
+    pub fn for_penumbra_testnet_phobos_2() -> anyhow::Result<NodeArchiveSeries> {
+        let chain_id = "penumbra-testnet-phobos-2".to_owned();
+        let archives: Vec<NodeArchive> = vec![
+            NodeArchive {
+                download_url: "https://artifacts.plinfra.net/penumbra-testnet-phobos-2/penumbra-node-archive-height-1459800-pre-upgrade.tar.gz".try_into()?,
+                checksum_sha256: "797e57b837acb3875b1b3948f89cdcb5446131a9eff73a40c77134550cf1b5f7".to_owned(),
+                chain_id: chain_id.clone(),
+            },
+
+            NodeArchive {
+                download_url: "https://artifacts.plinfra.net/penumbra-testnet-phobos-2/penumbra-node-archive-height-2358329-pre-upgrade.tar.gz".try_into()?,
+                checksum_sha256: "5a079394e041f4280c3dc8e8ef871ca109ccb7147da1f9626c6c585cac5dc1bc".to_owned(),
+                chain_id: chain_id.clone(),
+            },
+
+            NodeArchive {
+                download_url: "https://artifacts.plinfra.net/penumbra-testnet-phobos-2/penumbra-node-archive-height-3280053.tar.gz".try_into()?,
+                checksum_sha256: "e28f1a82845f4e2b3cd972ce8025a38b7e7e9fcbb3ee98efd766f984603988f4".to_owned(),
+                chain_id: chain_id.clone(),
+            },
+        ];
+
+        Ok(NodeArchiveSeries {
+            chain_id: chain_id.to_owned(),
+            archives,
+        })
+    }
+
+    /// List all sequential node state archives required
+    /// to reconstruct chain state for `penumbra-testnet-phobos-3`.
+    pub fn for_penumbra_testnet_phobos_3() -> anyhow::Result<NodeArchiveSeries> {
+        let chain_id = "penumbra-testnet-phobos-3".to_owned();
+        let archives: Vec<NodeArchive> = vec![NodeArchive {
+            download_url: "https://artifacts.plinfra.net/penumbra-testnet-phobos-3/penumbra-node-archive-height-368331.tar.gz".try_into()?,
+            checksum_sha256: "53b449e99f0663f1c46dcb50f61f53eae6c2892eb740d41e6d0ed068c3eb62fc"
+                .to_owned(),
+            chain_id: chain_id.clone(),
+        }];
+
+        Ok(NodeArchiveSeries {
+            chain_id: chain_id.to_owned(),
+            archives,
+        })
+    }
+
+    /// List all sequential node state archives required
+    /// to reconstruct chain state for `penumbra-1`.
+    pub fn for_penumbra_1() -> anyhow::Result<NodeArchiveSeries> {
+        let chain_id = "penumbra-1".to_owned();
+        let archives: Vec<NodeArchive> = vec![
+            NodeArchive {
+                download_url: "https://artifacts.plinfra.net/penumbra-1/penumbra-node-archive-height-501974-pre-upgrade.tar.gz".try_into()?,
+                checksum_sha256: "146462ee5c01fba5d13923ef20cec4a121cc58da37d61f04ce7ee41328d2cbd0".to_owned(),
+                chain_id: chain_id.clone(),
+
+            },
+
+            NodeArchive {
+                download_url: "https://artifacts.plinfra.net/penumbra-1/penumbra-node-archive-height-2611800-pre-upgrade.tar.gz".try_into()?,
+                checksum_sha256: "66e08e5d527607891136bddd9df768b8fd0ba8c7d57d0b6dc27976cc5a8fbbbb".to_owned(),
+                chain_id: chain_id.clone(),
+            },
+
+            NodeArchive {
+                download_url: "https://artifacts.plinfra.net/penumbra-1/penumbra-node-archive-height-4378762-pre-upgrade.tar.gz".try_into()?,
+                checksum_sha256: "9840c4d0c93a928412fc55faa6edfe69faa19aac662cc133d6a45c64d1e0062c".to_owned(),
+                chain_id: chain_id.clone(),
+            },
+
+            NodeArchive {
+                download_url: "https://artifacts.plinfra.net/penumbra-1/penumbra-node-archive-height-4836782.tar.gz".try_into()?,
+                checksum_sha256: "ffce4cfc5d783f0fc06645c4049b7affb8207b70e68012c9b33b46d108cdf996".to_owned(),
+                chain_id: chain_id.clone(),
+            },
+        ];
+
+        Ok(NodeArchiveSeries {
+            chain_id: chain_id.to_owned(),
+            archives,
+        })
+    }
+}

--- a/src/history/reindexer.rs
+++ b/src/history/reindexer.rs
@@ -1,0 +1,106 @@
+use flate2::read::GzDecoder;
+use std::path::PathBuf;
+use url::Url;
+
+use std::fs::File;
+use std::io::{copy, BufReader, BufWriter};
+
+/// An compressed file archive containing a `penumbra-reindexer` sqlite3 database.
+///
+/// Requires a download URL so the archive can be fetched, and a checksum
+/// so that the integrity can be verified.
+pub struct ReindexerArchive {
+    /// The chain id of the chain for which the archive provides history.
+    pub chain_id: String,
+    /// The URL from which the archive will be downloaded.
+    pub download_url: Url,
+    /// The SHA256 checksum for verifying the integrity of the archive post-download.
+    pub checksum_sha256: String,
+}
+
+impl ReindexerArchive {
+    /// Provide up comprehensive reindexer database for chain `penumbra-1`.
+    pub fn for_penumbra_1() -> ReindexerArchive {
+        let chain_id = "penumbra-1".to_owned();
+        ReindexerArchive {
+            download_url:
+                "https://artifacts.plinfra.net/penumbra-1/reindexer-archive-height-5598447.sqlite.gz"
+                    .try_into()
+                    .expect("failed to parse reindexer archive url"),
+            checksum_sha256: "ee430e6087f8864dbc08ceb3150cb2ee0363a53e7c79bfb00413f46c6f802f24"
+                .to_owned(),
+            chain_id: chain_id.clone(),
+        }
+    }
+
+    /// Provide up comprehensive reindexer database for chain `penumbra-testnet-phobos-2`.
+    pub fn for_penumbra_testnet_phobos_2() -> ReindexerArchive {
+        let chain_id = "penumbra-testnet-phobos-2".to_owned();
+        ReindexerArchive {
+            download_url: "https://artifacts.plinfra.net/penumbra-testnet-phobos-2/reindexer_archive-height-3352529.sqlite".try_into().expect("failed to parse reindexer archive url"),
+            checksum_sha256: "ab641c062aebfb389e3304fff7cbb6cdf45ce6094accbfab9cad76672e05fb51".to_owned(),
+            chain_id: chain_id.clone(),
+        }
+    }
+
+    /// Provide up comprehensive reindexer database for chain `penumbra-testnet-phobos-3`.
+    pub fn for_penumbra_testnet_phobos_3() -> ReindexerArchive {
+        let chain_id = "penumbra-testnet-phobos-3".to_owned();
+        ReindexerArchive {
+            download_url: "https://artifacts.plinfra.net/penumbra-testnet-phobos-3/reindexer_archive-height-997958.sqlite".try_into().expect("failed to parse reindexer archive url"),
+            checksum_sha256: "e2443fd39cb1567febb40515ed847f19e57022a9d083056dc46116ecb81990d5".to_owned(),
+            chain_id: chain_id.clone(),
+        }
+    }
+
+    /// Take a gzipped sqlite3 db and decompress it.
+    pub async fn extract(
+        &self,
+        compressed_file: &PathBuf,
+        dest_file: &PathBuf,
+    ) -> anyhow::Result<()> {
+        tracing::debug!("decompressing gzipped asset");
+        // Open input file with buffered reader
+        let compressed_f = File::open(compressed_file)?;
+        let r = BufReader::new(compressed_f);
+        let gz = GzDecoder::new(r);
+
+        // Open output file with buffered writer
+        let dest_f = File::create(dest_file)?;
+        let mut w = BufWriter::new(dest_f);
+
+        // Stream copy from decoder to output file
+        copy(&mut BufReader::new(gz), &mut w)?;
+
+        Ok(())
+    }
+
+    /// Fetch the archive from the `download_url` and save it locally.
+    pub async fn download(&self, dest_file: &PathBuf) -> anyhow::Result<()> {
+        crate::history::download(&self.download_url, dest_file, &self.checksum_sha256).await?;
+        Ok(())
+    }
+
+    /// Look up the node directory, by appending `node0`
+    /// to the `network_dir`.
+    pub fn node_dir(&self) -> PathBuf {
+        crate::files::default_penumbra_home()
+            .expect("failed to look up default penumbra home directory")
+    }
+}
+
+impl TryFrom<String> for ReindexerArchive {
+    type Error = anyhow::Error;
+    fn try_from(s: String) -> anyhow::Result<ReindexerArchive> {
+        // TODO refactor as enum
+        if s == *"penumbra-1" {
+            Ok(ReindexerArchive::for_penumbra_1())
+        } else if s == *"penumbra-testnet-phobos-2" {
+            Ok(ReindexerArchive::for_penumbra_testnet_phobos_2())
+        } else if s == *"penumbra-testnet-phobos-3" {
+            Ok(ReindexerArchive::for_penumbra_testnet_phobos_3())
+        } else {
+            anyhow::bail!("chain id '{}' is not supported", s);
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 use std::io::{stderr, IsTerminal as _};
 use tracing_subscriber::EnvFilter;
 
+pub mod check;
 mod cometbft;
 mod command;
 pub mod files;
@@ -22,6 +23,8 @@ pub enum Opt {
     Export(command::Export),
     /// Bootstrap initial config for the reindexer.
     Bootstrap(command::Bootstrap),
+    /// Inspect local reindexer archive and perform healthchecks on it.
+    Check(command::Check),
 }
 
 impl Opt {
@@ -32,6 +35,7 @@ impl Opt {
             Opt::Regen(x) => x.run().await,
             Opt::Export(x) => x.run().await,
             Opt::Bootstrap(x) => x.run().await,
+            Opt::Check(x) => x.run().await,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,8 @@ use tracing_subscriber::EnvFilter;
 
 mod cometbft;
 mod command;
-mod files;
+pub mod files;
+pub mod history;
 mod indexer;
 mod penumbra;
 pub mod storage;
@@ -19,6 +20,8 @@ pub enum Opt {
     Regen(command::Regen),
     /// Export data from the archive.
     Export(command::Export),
+    /// Bootstrap initial config for the reindexer.
+    Bootstrap(command::Bootstrap),
 }
 
 impl Opt {
@@ -28,11 +31,12 @@ impl Opt {
             Opt::Archive(x) => x.run().await,
             Opt::Regen(x) => x.run().await,
             Opt::Export(x) => x.run().await,
+            Opt::Bootstrap(x) => x.run().await,
         }
     }
 
     /// Initialize tracing for the console.
-    pub fn init_console_tracing(&self) {
+    pub fn init_console_tracing() {
         tracing_subscriber::fmt()
             .with_ansi(stderr().is_terminal())
             .with_target(true)

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,6 @@ use clap::Parser;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let opt = penumbra_reindexer::Opt::parse();
-    opt.init_console_tracing();
+    penumbra_reindexer::Opt::init_console_tracing();
     opt.run().await
 }

--- a/tests/file.rs
+++ b/tests/file.rs
@@ -3,7 +3,6 @@
 #[path = "common/mod.rs"]
 mod common;
 
-use common::init_tracing;
 use penumbra_reindexer::{storage::Storage, tendermint_compat};
 use std::path::PathBuf;
 use std::str::FromStr as _;
@@ -13,7 +12,7 @@ use std::str::FromStr as _;
 /// archived blocks. Exercises the conversion between multiple
 /// Tendermint crate versions, for backwards compatibility with historical chain data.
 async fn test_begin_block_parsing() -> anyhow::Result<()> {
-    init_tracing();
+    penumbra_reindexer::Opt::init_console_tracing();
     struct Args {
         archive_file: PathBuf,
     }


### PR DESCRIPTION
This PR adds two (2) new subcommands:

  * `penumbra-reindexer bootstrap`
  * `penumbra-reindexer check`
  
 The `bootstrap` command will fetch a remote sqlite3 db for a specific chain id. Gzipped compressed archives are supported, since that cuts filesize nearly in half. The `check` command will run a handful of healthchecks against a local db. In both cases, the bulk of the logic is pulled up from the integration tests (https://github.com/penumbra-zone/reindexer/pull/28) into the tool itself, so that operators can leverage the actions.

Significantly, :rotating_light:  **there are breaking changes to filepaths** :rotating_light::  there's now a `~/.local/share/penumbra-reindexer/` home directory for the reindexer, inside which downloaded archives will be stored. The default path for a reindexer archive is now `~/.local/share/penumbra-reindexer/<CHAIN_ID>/reindexer-archive.sqlite`. A reindexer setup can now store archives across multiple chains, and keep them straight. The various subcommands accept a `--home` flag to target the new homedir; flags pointing to a node's home dir have been renamed to `--node-home`. 
 
### Testing and review

I recommend test-driving the new experience by running `just integration`, which will exercise `bootstrap`, remote block fetching via `archive`, and `check` mode, and display some pretty progress bars while doing so.

### Further work

I've not ported over the `regen` logic, so the old-style integration tests are still in place. This diff is large enough, so I'm submitting as a PR, and will continue to work on more automation, possibly including picturesque https://github.com/penumbra-zone/penumbra/pull/5228.
 