### PR TITLE
feat: automatic "regen" subcommand

### DIFF
--- a/justfile
+++ b/justfile
@@ -18,11 +18,14 @@ integration:
   # TODO we should port the logic back into cargo-nextest
   # cargo nextest run --release --features network-integration --nocapture
 
-  cargo run -- bootstrap --home test_data/ephemeral-storage --force
-  cargo run -- archive --home test_data/ephemeral-storage --remote-rpc https://rpc-penumbra.radiantcommons.com
+  cargo run -- bootstrap --home test_data/ephemeral-storage
+  # ideally we'd top up the archive based on remote, but this can add ~20m
+  # cargo run -- archive --home test_data/ephemeral-storage --remote-rpc https://rpc-penumbra.radiantcommons.com
+
+  # check that the archive is valid
   cargo run -- check --home test_data/ephemeral-storage
   # TODO: use picturesque to set up a local psql db for testing
-  # cargo run -- regen --home test_data/ephemeral-storage --database-url postgresql://penumbra:penumbra@127.0.0.1:5432/regen
+  # cargo run -- regen --home test_data/ephemeral-storage --chain-id penumbra-1 --database-url postgresql://penumbra:penumbra@127.0.0.1:5432/regen
 
 # Run expensive tests that require local files as input. Assumes integration tests have been run!
 expensive-tests:
@@ -41,4 +44,8 @@ container:
   #
   #   docker load < result
   #   docker run -it localhost/penumbra-reindexer:0.5.0 bash
-  #
+
+# dev-only helper to reset a local psql database
+unsafe-reset-local-db:
+  sudo -u postgres psql -c 'DROP DATABASE regen;' || true
+  sudo -u postgres psql -c 'CREATE DATABASE regen WITH OWNER penumbra;'

--- a/src/command.rs
+++ b/src/command.rs
@@ -3,9 +3,11 @@ mod bootstrap;
 mod check;
 mod export;
 mod regen;
+mod regen_step;
 
 pub use archive::Archive;
 pub use bootstrap::Bootstrap;
 pub use check::Check;
 pub use export::Export;
-pub use regen::Regen;
+pub use regen::RegenAuto;
+pub use regen_step::Regen;

--- a/src/command/regen.rs
+++ b/src/command/regen.rs
@@ -1,30 +1,13 @@
 use std::path::PathBuf;
+use std::process::Command;
 
-use crate::{
-    cometbft::{RemoteStore, Store},
-    indexer::{Indexer, IndexerOpts},
-    penumbra::Regenerator,
-    storage::Storage,
-};
+use crate::penumbra::RegenerationPlan;
 
 #[derive(clap::Parser)]
-pub struct Regen {
+pub struct RegenAuto {
     /// The URL for the database where we should store the produced events.
     #[clap(long)]
     database_url: String,
-    /// The directory containing pd and cometbft data for a full node.
-    ///
-    /// In this directory we expect there to be:
-    ///
-    /// - ./cometbft/config/config.toml, for reading cometbft configuration
-    /// - ./cometbft/data/, for reading historical blocks
-    ///
-    /// Defaults to `~/.penumbra/network_data/node0`, the same default used for `pd start`.
-    ///
-    /// The node state will be read from this directory, and saved inside
-    /// an sqlite3 database at ~/.local/share/penumbra-reindexer/<CHAIN_ID>/reindexer-archive.sqlite.
-    #[clap(long)]
-    node_home: Option<PathBuf>,
 
     /// The home directory for the penumbra-reindexer.
     ///
@@ -40,27 +23,11 @@ pub struct Regen {
     #[clap(long)]
     archive_file: Option<PathBuf>,
 
-    /// If set, index events starting from this height.
-    #[clap(long)]
-    start_height: Option<u64>,
-
-    /// If set, index events up to and including this height.
-    ///
-    /// For example, if this is set to 2, only events in blocks 1, 2 will be indexed.
-    #[clap(long)]
-    stop_height: Option<u64>,
-
     /// If set, use a given directory to store the working reindexing state.
     ///
     /// This allows resumption of reindexing, by reusing the directory.
     #[clap(long)]
     working_dir: Option<PathBuf>,
-
-    /// If set, poll a remote CometBFT RPC URL to fetch new blocks continuously.
-    ///
-    /// If a stop height is not set, this will run regeneration indefinitely.
-    #[clap(long)]
-    follow: Option<String>,
 
     /// If set, allows the indexing database to have data.
     ///
@@ -77,59 +44,129 @@ pub struct Regen {
     /// If the chain id in the sqlite3 database doesn't match this value,
     /// the program will exit with an error.
     chain_id: Option<String>,
+
+    /// If set, remove the working directory before starting regeneration.
+    ///
+    /// This ensures a clean state for regeneration but will remove any
+    /// existing regeneration progress.
+    #[clap(long)]
+    clean: bool,
 }
 
-impl Regen {
-    /// Resolve the path of the archive file
-    fn archive_file(&self) -> anyhow::Result<PathBuf> {
-        crate::files::archive_filepath_from_opts(
+impl RegenAuto {
+    pub async fn run(self) -> anyhow::Result<()> {
+        // Determine chain_id - default to penumbra-1 if not specified
+        let chain_id = self.chain_id.as_deref().unwrap_or("penumbra-1");
+        let home = self
+            .home
+            .clone()
+            .unwrap_or(crate::files::default_reindexer_home()?);
+        let archive_file = crate::files::archive_filepath_from_opts(
             self.home.clone(),
             self.archive_file.clone(),
             self.chain_id.clone(),
-        )
-    }
+        )?;
 
-    pub async fn run(self) -> anyhow::Result<()> {
-        let archive_file = self.archive_file()?;
+        // Determine working dir
+        let working_dir = self
+            .working_dir
+            .clone()
+            .unwrap_or(crate::files::default_regen_working_dir(&home, chain_id));
 
-        let store: Option<Box<dyn Store>> = match self.follow {
-            None => None,
-            Some(x) => Some(Box::new(RemoteStore::new(x))),
-        };
-
-        let chain_id = match store.as_ref() {
-            None => {
-                tracing::info!("no chain_id specified, defaulting to 'penumbra-1'");
-                String::from("penumbra-1")
-            }
-            Some(store) => {
-                let genesis = store.get_genesis().await?;
-                genesis.chain_id()
-            }
-        };
-
-        let archive = Storage::new(Some(&archive_file), Some(&chain_id)).await?;
-        let working_dir = match self.working_dir {
-            Some(d) => d,
-            None => {
-                let p = crate::files::default_reindexer_home()?
-                    .join(chain_id)
-                    .join("regen-working-dir");
-
-                tracing::debug!(
-                    "working dir not specified, defaulting to {}",
-                    p.display().to_string()
+        // Handle clean option - remove working directory if it exists
+        if self.clean {
+            if working_dir.exists() {
+                tracing::info!(
+                    "Removing existing working directory: {}",
+                    working_dir.display()
                 );
-                p
+                std::fs::remove_dir_all(&working_dir)?;
+            } else {
+                tracing::info!("Working directory does not exist, nothing to clean");
             }
-        };
+        }
 
-        let indexer_opts = IndexerOpts {
-            allow_existing_data: self.allow_existing_data,
-        };
-        let indexer = Indexer::init(&self.database_url, indexer_opts).await?;
-        let regenerator = Regenerator::load(&working_dir, archive, indexer, store).await?;
+        // Get the regeneration plan for this chain
+        let plan = RegenerationPlan::from_known_chain_id(chain_id).ok_or_else(|| {
+            anyhow::anyhow!("no regeneration plan known for chain id '{}'", chain_id)
+        })?;
 
-        regenerator.run(self.start_height, self.stop_height).await
+        tracing::info!("starting automatic regeneration for chain: {}", chain_id);
+        tracing::debug!(
+            "found {} regeneration steps, including migrations",
+            plan.steps.len()
+        );
+
+        // Get current executable path
+        let current_exe = std::env::current_exe()?;
+
+        // Extract stop heights from InitThenRunTo steps that have a last_block
+        // The RegenerationPlan already handles the proper sequencing of migrate and run steps
+        let mut regen_invocations = Vec::new();
+
+        for (_, step) in &plan.steps {
+            if let crate::penumbra::RegenerationStep::InitThenRunTo { last_block, .. } = step {
+                regen_invocations.push(*last_block);
+            }
+        }
+
+        tracing::info!(
+            "will execute {} regen commands with stop heights: {:?}",
+            regen_invocations.len(),
+            regen_invocations
+        );
+
+        for (i, stop_height) in regen_invocations.iter().enumerate() {
+            let mut cmd = Command::new(&current_exe);
+            // Shell out to the internal "regen-step" command, so that the "sys::exit" calls in
+            // upstream Penumbra deps don't cause the current penumbra-reindexer process to exit.
+            cmd.arg("regen-step")
+                .arg("--chain-id")
+                .arg(chain_id)
+                .arg("--home")
+                .arg(&home)
+                .arg("--working-dir")
+                .arg(&working_dir)
+                .arg("--archive-file")
+                .arg(&archive_file)
+                .arg("--database-url")
+                .arg(&self.database_url);
+
+            if self.allow_existing_data {
+                cmd.arg("--allow-existing-data");
+            }
+
+            // Add stop height if present
+            if let Some(height) = stop_height {
+                cmd.arg("--stop-height").arg(height.to_string());
+                tracing::info!(
+                    "executing regen command {} of {} (stop-height: {})",
+                    i + 1,
+                    regen_invocations.len(),
+                    height
+                );
+            } else {
+                tracing::info!(
+                    "executing final regen command {} of {} (no stop-height)",
+                    i + 1,
+                    regen_invocations.len()
+                );
+            }
+            tracing::debug!("regen command is: {:?}", cmd);
+            let status = cmd.status()?;
+
+            if !status.success() {
+                return Err(anyhow::anyhow!(
+                    "regen command {} failed with exit code: {:?}",
+                    i + 1,
+                    status.code()
+                ));
+            }
+
+            tracing::info!("regen command {} completed successfully", i + 1);
+        }
+
+        tracing::info!("all regeneration steps completed successfully");
+        Ok(())
     }
 }

--- a/src/command/regen_step.rs
+++ b/src/command/regen_step.rs
@@ -1,0 +1,130 @@
+use std::path::PathBuf;
+
+use crate::{
+    cometbft::{RemoteStore, Store},
+    indexer::{Indexer, IndexerOpts},
+    penumbra::Regenerator,
+    storage::Storage,
+};
+
+#[derive(clap::Parser)]
+pub struct Regen {
+    /// The URL for the database where we should store the produced events.
+    #[clap(long)]
+    database_url: String,
+    /// The directory containing pd and cometbft data for a full node.
+    ///
+    /// In this directory we expect there to be:
+    ///
+    /// - ./cometbft/config/config.toml, for reading cometbft configuration
+    /// - ./cometbft/data/, for reading historical blocks
+    ///
+    /// Defaults to `~/.penumbra/network_data/node0`, the same default used for `pd start`.
+    ///
+    /// The node state will be read from this directory, and saved inside
+    /// an sqlite3 database at ~/.local/share/penumbra-reindexer/<CHAIN_ID>/reindexer-archive.sqlite.
+    #[clap(long)]
+    node_home: Option<PathBuf>,
+
+    /// The home directory for the penumbra-reindexer.
+    ///
+    /// Downloaded large files will be stored within this directory.
+    ///
+    /// Defaults to `~/.local/share/penumbra-reindexer`.
+    /// Can be overridden with --archive-file.
+    #[clap(long)]
+    home: Option<PathBuf>,
+
+    /// Override the location of the sqlite3 database from which event data will be read.
+    /// Defaults to `<HOME>/reindexer_archive.bin`.
+    #[clap(long)]
+    archive_file: Option<PathBuf>,
+
+    /// If set, index events starting from this height.
+    #[clap(long)]
+    start_height: Option<u64>,
+
+    /// If set, index events up to and including this height.
+    ///
+    /// For example, if this is set to 2, only events in blocks 1, 2 will be indexed.
+    #[clap(long)]
+    stop_height: Option<u64>,
+
+    /// If set, use a given directory to store the working reindexing state.
+    ///
+    /// This allows resumption of reindexing, by reusing the directory.
+    #[clap(long)]
+    working_dir: Option<PathBuf>,
+
+    /// If set, poll a remote CometBFT RPC URL to fetch new blocks continuously.
+    ///
+    /// If a stop height is not set, this will run regeneration indefinitely.
+    #[clap(long)]
+    follow: Option<String>,
+
+    /// If set, allows the indexing database to have data.
+    ///
+    /// This will make the indexer add any data that's not there
+    /// (e.g. blocks that are missing, etc.). The indexer will not overwrite existing
+    /// data, and simply skip indexing anything that would do so.
+    #[clap(long)]
+    allow_existing_data: bool,
+
+    #[clap(long)]
+    /// Specify a network for which events should be regenerated.
+    ///
+    /// The sqlite3 database must already have events in it from this chain.
+    /// If the chain id in the sqlite3 database doesn't match this value,
+    /// the program will exit with an error.
+    chain_id: Option<String>,
+}
+
+impl Regen {
+    pub async fn run(self) -> anyhow::Result<()> {
+        let archive_file = crate::files::archive_filepath_from_opts(
+            self.home.clone(),
+            self.archive_file.clone(),
+            self.chain_id.clone(),
+        )?;
+
+        let store: Option<Box<dyn Store>> = match self.follow {
+            None => None,
+            Some(x) => Some(Box::new(RemoteStore::new(x))),
+        };
+
+        let chain_id = match store.as_ref() {
+            None => {
+                tracing::info!("no chain_id specified, defaulting to 'penumbra-1'");
+                String::from("penumbra-1")
+            }
+            Some(store) => {
+                let genesis = store.get_genesis().await?;
+                genesis.chain_id()
+            }
+        };
+
+        let archive = Storage::new(Some(&archive_file), Some(&chain_id)).await?;
+        let working_dir = match self.working_dir {
+            Some(d) => d,
+            None => {
+                let p = crate::files::default_reindexer_home()?
+                    .join(chain_id)
+                    .join("regen-working-dir");
+
+                tracing::debug!(
+                    "working dir not specified, defaulting to {}",
+                    p.display().to_string()
+                );
+                p
+            }
+        };
+
+        let indexer_opts = IndexerOpts {
+            allow_existing_data: self.allow_existing_data,
+        };
+        let indexer = Indexer::init(&self.database_url, indexer_opts).await?;
+        let regenerator = Regenerator::load(&working_dir, archive, indexer, store).await?;
+
+        regenerator.run(self.start_height, self.stop_height).await
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,11 @@ pub enum Opt {
     /// Create or add to our full historical archive.
     Archive(command::Archive),
     /// Regenerate an index of events, given a historical archive.
-    Regen(command::Regen),
+    Regen(command::RegenAuto),
+    /// Internal-only subcommand, used by `Regen` to regenerate segments of the chain by protocol
+    /// version.
+    #[command(hide = true)]
+    RegenStep(command::Regen),
     /// Export data from the archive.
     Export(command::Export),
     /// Bootstrap initial config for the reindexer.
@@ -33,6 +37,7 @@ impl Opt {
         match self {
             Opt::Archive(x) => x.run().await,
             Opt::Regen(x) => x.run().await,
+            Opt::RegenStep(x) => x.run().await,
             Opt::Export(x) => x.run().await,
             Opt::Bootstrap(x) => x.run().await,
             Opt::Check(x) => x.run().await,

--- a/src/penumbra.rs
+++ b/src/penumbra.rs
@@ -48,7 +48,7 @@ async fn make_a_penumbra(version: Version, working_dir: &Path) -> anyhow::Result
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
-enum Version {
+pub enum Version {
     V0o79,
     V0o80,
     V1o3,
@@ -57,7 +57,7 @@ enum Version {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
-enum RegenerationStep {
+pub enum RegenerationStep {
     /// Represents a migration, as would be performed by `pd migrate`,
     /// so munge node state on a planned upgrade boundary.
     Migrate { from: Version, to: Version },
@@ -206,7 +206,7 @@ impl RegenerationStep {
 /// This also makes the resulting logic in terms of creating and destroying penumbra applications
 /// easier, because we know the given lifecycle of a version of the penumbra logic.
 #[derive(Debug)]
-struct RegenerationPlan {
+pub struct RegenerationPlan {
     pub steps: Vec<(u64, RegenerationStep)>,
 }
 

--- a/tests/network_integration.rs
+++ b/tests/network_integration.rs
@@ -8,7 +8,7 @@
 //! can be reconstructed, across any and all upgrade boundaries.
 //!
 //! Right now, however, only the `penumbra-reindexer archive` step is exercised.
-//! Further work should confirm that `penumbra-reindexer regen` is exercised,
+//! Further work should confirm that `penumbra-reindexer regen-step` is exercised,
 //! and assertions made on the database contents.
 
 mod common;


### PR DESCRIPTION
Updates the "regen" logic to infer the regeneration plan based on chain id, and run the regeneration logic for each relevant protocol version. This removes the need to wrap the regen invocation with a script to feed in all relevant `--stop-height` flags.                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                              
In a nutshell, this change:

* renames "regen" -> "regen-step"
* adds a new "regen" subcmd that reads RegenerationPlan
* shells out via current_exe to "regen-step" according to plan
                                                                                                                                                                                                                                                                                                                              
The trick of shelling out via current_exe is employed to sidestep the rough edge in the upstream Penumbra logic that calls sys-exit on upgrade boundaries, which will cause the `penumbra-reindexer` process to terminate, too, unless we shell out to it. This is a bit of a hack, but in the interest of ergonomics, we can sweep the complexity into an internal-only subcommand by "hiding" the "regen-step" logic via clap.

Includes minor updates to README to match.

### Testing and review

Remember that a full regen takes a long time. That said, here's the procedure:

0. Create an empty pg database to store the generated events
1. `penumbra-reindexer bootstrap` to download an sqlite3 archive from the public repo
2. `penumbra-reindexer regen --database-url <DATABASE_URL>` to regen

In particular, it's important to observe that the regen process makes it over at least one upgrade boundary. For `penumbra-1`, the first is at `501974`, so you can probably get there in a few hours. 