### PR TITLE
fix: add back missing index on events(block_id)

### DIFF
--- a/src/indexer/schema.sql
+++ b/src/indexer/schema.sql
@@ -29,6 +29,8 @@ CREATE TABLE IF NOT EXISTS events (
   type VARCHAR NOT NULL
 );
 
+CREATE INDEX IF NOT EXISTS idx_events_block_id ON events(block_id);
+
 CREATE TABLE IF NOT EXISTS attributes (
    event_id      BIGINT NOT NULL REFERENCES events(rowid),
    key           VARCHAR NOT NULL,


### PR DESCRIPTION
This was causing performance slowdowns, and is a difference between this schema, and the cometindex schema.

Likely, we forgot to update this one here when we made the change to cometindex.